### PR TITLE
Crawl to update geom_src properties

### DIFF
--- a/data/112/590/551/3/1125905513.geojson
+++ b/data/112/590/551/3/1125905513.geojson
@@ -482,6 +482,9 @@
     },
     "wof:country":"PY",
     "wof:created":1497295973,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"5322a896d6b3977d5f5e73ea894fc487",
     "wof:hierarchy":[
         {
@@ -493,7 +496,7 @@
         }
     ],
     "wof:id":1125905513,
-    "wof:lastmodified":1566609611,
+    "wof:lastmodified":1582360318,
     "wof:name":"Asunci\u00f3n",
     "wof:parent_id":421166713,
     "wof:placetype":"locality",

--- a/data/421/166/713/421166713.geojson
+++ b/data/421/166/713/421166713.geojson
@@ -89,6 +89,9 @@
     ],
     "wof:country":"PY",
     "wof:created":1459008700,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5322a896d6b3977d5f5e73ea894fc487",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421166713,
-    "wof:lastmodified":1566609550,
+    "wof:lastmodified":1582360298,
     "wof:name":"Asuncion",
     "wof:parent_id":85676651,
     "wof:placetype":"county",

--- a/data/421/166/801/421166801.geojson
+++ b/data/421/166/801/421166801.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008703,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e11e7a0af5e37c01f2333748b1247ce1",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421166801,
-    "wof:lastmodified":1566609550,
+    "wof:lastmodified":1582360298,
     "wof:name":"Belen",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/421/169/437/421169437.geojson
+++ b/data/421/169/437/421169437.geojson
@@ -276,6 +276,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008810,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78a87827760444e03fb57afa6b407437",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         }
     ],
     "wof:id":421169437,
-    "wof:lastmodified":1566609556,
+    "wof:lastmodified":1582360300,
     "wof:name":"Ciudad Del Este",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/170/007/421170007.geojson
+++ b/data/421/170/007/421170007.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008833,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b82526e9721ae65454b0f6ce409c18d",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421170007,
-    "wof:lastmodified":1566609585,
+    "wof:lastmodified":1582360309,
     "wof:name":"Pilar",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/421/170/009/421170009.geojson
+++ b/data/421/170/009/421170009.geojson
@@ -202,6 +202,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008833,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"913beff254d54e873195f99ed9beb6fd",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":421170009,
-    "wof:lastmodified":1566609585,
+    "wof:lastmodified":1582360309,
     "wof:name":"Ypacarai",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/170/011/421170011.geojson
+++ b/data/421/170/011/421170011.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008833,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f23c697b9115e98e274b1feb583034b5",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421170011,
-    "wof:lastmodified":1566609586,
+    "wof:lastmodified":1582360309,
     "wof:name":"Paso De Patria",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/421/170/013/421170013.geojson
+++ b/data/421/170/013/421170013.geojson
@@ -232,6 +232,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008833,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"031db9626ced81f03d0978f72cbeca90",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         }
     ],
     "wof:id":421170013,
-    "wof:lastmodified":1566609584,
+    "wof:lastmodified":1582360308,
     "wof:name":"Limpio",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/170/015/421170015.geojson
+++ b/data/421/170/015/421170015.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008833,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea0c8f2c5c6d3fea62b8a0860476f112",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421170015,
-    "wof:lastmodified":1566609583,
+    "wof:lastmodified":1582360308,
     "wof:name":"Carapegua",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/421/170/017/421170017.geojson
+++ b/data/421/170/017/421170017.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008833,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8de3f4595b82a04638b80dc0f4fd1cf",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421170017,
-    "wof:lastmodified":1566609586,
+    "wof:lastmodified":1582360309,
     "wof:name":"San Ignacio",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/170/055/421170055.geojson
+++ b/data/421/170/055/421170055.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8984fce5beef1894a463c2833007810",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":421170055,
-    "wof:lastmodified":1566609586,
+    "wof:lastmodified":1582360309,
     "wof:name":"Aregua",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/170/059/421170059.geojson
+++ b/data/421/170/059/421170059.geojson
@@ -241,6 +241,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008835,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"90bbb4acff62efe6b49d3dadc5bea4c3",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         }
     ],
     "wof:id":421170059,
-    "wof:lastmodified":1566609587,
+    "wof:lastmodified":1582360310,
     "wof:name":"Pedro Juan Caballero",
     "wof:parent_id":85676701,
     "wof:placetype":"county",

--- a/data/421/171/367/421171367.geojson
+++ b/data/421/171/367/421171367.geojson
@@ -226,6 +226,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fac14c3656ce196b0ceb28db14a06da6",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":421171367,
-    "wof:lastmodified":1566609601,
+    "wof:lastmodified":1582360315,
     "wof:name":"Villa Hayes",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/421/171/369/421171369.geojson
+++ b/data/421/171/369/421171369.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008891,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"188ca08a0962517078f65e00d0022bf4",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421171369,
-    "wof:lastmodified":1566609600,
+    "wof:lastmodified":1582360314,
     "wof:name":"Trinidad",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/171/423/421171423.geojson
+++ b/data/421/171/423/421171423.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008893,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97c06517a05e0da8e5889f7851a1931a",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421171423,
-    "wof:lastmodified":1566609595,
+    "wof:lastmodified":1582360312,
     "wof:name":"San Cosme Y Damian",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/171/521/421171521.geojson
+++ b/data/421/171/521/421171521.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008896,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14e3a9afa38d2b941727a01b2bda3237",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":421171521,
-    "wof:lastmodified":1566609595,
+    "wof:lastmodified":1582360312,
     "wof:name":"Nanawa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/171/537/421171537.geojson
+++ b/data/421/171/537/421171537.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da1f0c4c7ca5bc7283e9c14954737be8",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421171537,
-    "wof:lastmodified":1566609599,
+    "wof:lastmodified":1582360314,
     "wof:name":"Presidente Franco",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/171/777/421171777.geojson
+++ b/data/421/171/777/421171777.geojson
@@ -205,6 +205,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008906,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1dff838ba5ab3b0351a6b32cdbe1fe70",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         }
     ],
     "wof:id":421171777,
-    "wof:lastmodified":1566609596,
+    "wof:lastmodified":1582360313,
     "wof:name":"Mariscal Estigarribia",
     "wof:parent_id":85676659,
     "wof:placetype":"county",

--- a/data/421/171/779/421171779.geojson
+++ b/data/421/171/779/421171779.geojson
@@ -202,6 +202,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008906,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e0373879c7ec7785c33cdd326539742",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":421171779,
-    "wof:lastmodified":1566609597,
+    "wof:lastmodified":1582360313,
     "wof:name":"Benjamin Aceval",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/421/171/781/421171781.geojson
+++ b/data/421/171/781/421171781.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008906,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0686075d52fe9e4e7e7ea7e93a5796b",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421171781,
-    "wof:lastmodified":1566609606,
+    "wof:lastmodified":1582360318,
     "wof:name":"Villa Florida",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/171/783/421171783.geojson
+++ b/data/421/171/783/421171783.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"568750fd044f10a47c19e44f5187f631",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421171783,
-    "wof:lastmodified":1566609596,
+    "wof:lastmodified":1582360313,
     "wof:name":"Atyra",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/172/673/421172673.geojson
+++ b/data/421/172/673/421172673.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008950,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fa5aab815965820103b9e17ef23f35a",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":421172673,
-    "wof:lastmodified":1566609569,
+    "wof:lastmodified":1582360303,
     "wof:name":"Caacupe",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/172/933/421172933.geojson
+++ b/data/421/172/933/421172933.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008959,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"449898bbaa4b154c22bad31c6c0172ec",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421172933,
-    "wof:lastmodified":1566609570,
+    "wof:lastmodified":1582360304,
     "wof:name":"General Eugenio A. Garay",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/421/173/299/421173299.geojson
+++ b/data/421/173/299/421173299.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"87fbad3f40d7f8dac655096751ca3133",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421173299,
-    "wof:lastmodified":1566609565,
+    "wof:lastmodified":1582360301,
     "wof:name":"Tobati",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/173/301/421173301.geojson
+++ b/data/421/173/301/421173301.geojson
@@ -240,6 +240,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459008977,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c7b653ba84e9135de5147c355ec580c2",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
         }
     ],
     "wof:id":421173301,
-    "wof:lastmodified":1566609563,
+    "wof:lastmodified":1582360301,
     "wof:name":"Villarrica",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/421/173/745/421173745.geojson
+++ b/data/421/173/745/421173745.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009004,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c7db62937b03cd10336ffb1e252bc1ea",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         }
     ],
     "wof:id":421173745,
-    "wof:lastmodified":1566609565,
+    "wof:lastmodified":1582360302,
     "wof:name":"Paraguari",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/421/173/815/421173815.geojson
+++ b/data/421/173/815/421173815.geojson
@@ -241,6 +241,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009006,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4162252f598889db6e0813e9940f5efa",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
         }
     ],
     "wof:id":421173815,
-    "wof:lastmodified":1561830088,
+    "wof:lastmodified":1582360301,
     "wof:name":"Pilar",
     "wof:parent_id":421170007,
     "wof:placetype":"locality",

--- a/data/421/175/585/421175585.geojson
+++ b/data/421/175/585/421175585.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009072,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5f2392989aa664b18efc7356579080f",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421175585,
-    "wof:lastmodified":1566609572,
+    "wof:lastmodified":1582360304,
     "wof:name":"Altos",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/180/053/421180053.geojson
+++ b/data/421/180/053/421180053.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009243,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6bfe690c61bb94e8eb0b8bf365983b6b",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421180053,
-    "wof:lastmodified":1566609562,
+    "wof:lastmodified":1582360301,
     "wof:name":"Capitan Miranda",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/180/931/421180931.geojson
+++ b/data/421/180/931/421180931.geojson
@@ -181,6 +181,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009276,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4443b9b76e525f18662c34a507a5f3a0",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":421180931,
-    "wof:lastmodified":1566609560,
+    "wof:lastmodified":1582360301,
     "wof:name":"San Juan Bautista",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/182/833/421182833.geojson
+++ b/data/421/182/833/421182833.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009348,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"90b32a34fe134c458f374d31612e6c88",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421182833,
-    "wof:lastmodified":1566609593,
+    "wof:lastmodified":1582360312,
     "wof:name":"Los Cedrales",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/183/417/421183417.geojson
+++ b/data/421/183/417/421183417.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009368,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"760387e94fefa591674b896e5339f4ac",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":421183417,
-    "wof:lastmodified":1566609590,
+    "wof:lastmodified":1582360311,
     "wof:name":"Caaguazu",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/421/184/207/421184207.geojson
+++ b/data/421/184/207/421184207.geojson
@@ -234,6 +234,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009403,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60d8a3f1531e07e464411781e4f01699",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         }
     ],
     "wof:id":421184207,
-    "wof:lastmodified":1566609580,
+    "wof:lastmodified":1582360306,
     "wof:name":"Coronel Oviedo",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/421/184/635/421184635.geojson
+++ b/data/421/184/635/421184635.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40587ce59111cbe7e21648780f8b7784",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421184635,
-    "wof:lastmodified":1566609578,
+    "wof:lastmodified":1582360305,
     "wof:name":"Alto Vera",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/184/639/421184639.geojson
+++ b/data/421/184/639/421184639.geojson
@@ -220,6 +220,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9b275886bc40c8d13f1f41ddf685345",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         }
     ],
     "wof:id":421184639,
-    "wof:lastmodified":1566609581,
+    "wof:lastmodified":1582360307,
     "wof:name":"Fuerte Olimpo",
     "wof:parent_id":85676655,
     "wof:placetype":"county",

--- a/data/421/184/641/421184641.geojson
+++ b/data/421/184/641/421184641.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009417,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d62c53703a4fc0d8310ec62777d71f88",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421184641,
-    "wof:lastmodified":1566609579,
+    "wof:lastmodified":1582360306,
     "wof:name":"Piribebuy",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/184/917/421184917.geojson
+++ b/data/421/184/917/421184917.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009426,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"795e37d4adc4e452b000a829620046eb",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421184917,
-    "wof:lastmodified":1566609583,
+    "wof:lastmodified":1582360308,
     "wof:name":"Mbocayaty",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/421/186/729/421186729.geojson
+++ b/data/421/186/729/421186729.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009489,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"016d78f25decaaecc48f8c301ea40030",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
         }
     ],
     "wof:id":421186729,
-    "wof:lastmodified":1566609572,
+    "wof:lastmodified":1582360304,
     "wof:name":"Fuerte Olimpo",
     "wof:parent_id":421184639,
     "wof:placetype":"locality",

--- a/data/421/186/733/421186733.geojson
+++ b/data/421/186/733/421186733.geojson
@@ -192,6 +192,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009490,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4892b7d305bea4a4ae27714e1f51f46b",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421186733,
-    "wof:lastmodified":1566609571,
+    "wof:lastmodified":1582360304,
     "wof:name":"San Juan Bautista",
     "wof:parent_id":421180931,
     "wof:placetype":"locality",

--- a/data/421/187/353/421187353.geojson
+++ b/data/421/187/353/421187353.geojson
@@ -350,6 +350,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009510,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"0ba31d4ecdb51071ab75bdf40ef46b13",
     "wof:hierarchy":[
         {
@@ -361,7 +364,7 @@
         }
     ],
     "wof:id":421187353,
-    "wof:lastmodified":1566609563,
+    "wof:lastmodified":1582360301,
     "wof:name":"Ciudad del Este",
     "wof:parent_id":421169437,
     "wof:placetype":"locality",

--- a/data/421/189/017/421189017.geojson
+++ b/data/421/189/017/421189017.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009602,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2bc915ccedd712f3a522b2c9aaa9892",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421189017,
-    "wof:lastmodified":1566609569,
+    "wof:lastmodified":1582360303,
     "wof:name":"General Diaz",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/421/189/267/421189267.geojson
+++ b/data/421/189/267/421189267.geojson
@@ -256,6 +256,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc0e4f3c479cd05424669c165f59abe5",
     "wof:hierarchy":[
         {
@@ -266,7 +269,7 @@
         }
     ],
     "wof:id":421189267,
-    "wof:lastmodified":1566609566,
+    "wof:lastmodified":1582360302,
     "wof:name":"Luque",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/189/517/421189517.geojson
+++ b/data/421/189/517/421189517.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a73e64fb108cc83408698022ef743a6f",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421189517,
-    "wof:lastmodified":1566609567,
+    "wof:lastmodified":1582360303,
     "wof:name":"San Estanislao",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/421/189/519/421189519.geojson
+++ b/data/421/189/519/421189519.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009627,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec7ce6083ce9d612ab03a42ad17bf2c8",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421189519,
-    "wof:lastmodified":1566609568,
+    "wof:lastmodified":1582360303,
     "wof:name":"Carmen Del Parana",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/191/491/421191491.geojson
+++ b/data/421/191/491/421191491.geojson
@@ -241,6 +241,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27d93a507e1e1bd62deb5a0904a06ad7",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         }
     ],
     "wof:id":421191491,
-    "wof:lastmodified":1566609575,
+    "wof:lastmodified":1582360304,
     "wof:name":"Lambare",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/191/497/421191497.geojson
+++ b/data/421/191/497/421191497.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"018d785192787f07ed17b627b31132c0",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421191497,
-    "wof:lastmodified":1566609574,
+    "wof:lastmodified":1582360304,
     "wof:name":"Sapucai",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/421/191/499/421191499.geojson
+++ b/data/421/191/499/421191499.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009694,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfe0b6b90e49366bd1139f0c961bc3d8",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":421191499,
-    "wof:lastmodified":1566609574,
+    "wof:lastmodified":1582360304,
     "wof:name":"Yguazu",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/193/197/421193197.geojson
+++ b/data/421/193/197/421193197.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009763,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c073e15fa29957bf6875329355564b0",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421193197,
-    "wof:lastmodified":1566609555,
+    "wof:lastmodified":1582360300,
     "wof:name":"San Bernardino",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/193/629/421193629.geojson
+++ b/data/421/193/629/421193629.geojson
@@ -211,6 +211,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009777,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de08669f4d40305e5e89dcf1c377cb29",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":421193629,
-    "wof:lastmodified":1566609554,
+    "wof:lastmodified":1582360300,
     "wof:name":"Hernandarias",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/194/353/421194353.geojson
+++ b/data/421/194/353/421194353.geojson
@@ -252,6 +252,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009803,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"9649baddb9d9969fed9d30de16f19cde",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
         }
     ],
     "wof:id":421194353,
-    "wof:lastmodified":1566609554,
+    "wof:lastmodified":1582360299,
     "wof:name":"Mariscal Jos\u00e9 F. Estigarribia",
     "wof:parent_id":421171777,
     "wof:placetype":"locality",

--- a/data/421/194/567/421194567.geojson
+++ b/data/421/194/567/421194567.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009812,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff1d9e82d05cc5c32a45ab7d91d1391f",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":421194567,
-    "wof:lastmodified":1566609553,
+    "wof:lastmodified":1582360299,
     "wof:name":"Capiata",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/195/021/421195021.geojson
+++ b/data/421/195/021/421195021.geojson
@@ -208,6 +208,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bb02914aae4f494d89eee146b2a094c",
     "wof:hierarchy":[
         {
@@ -218,7 +221,7 @@
         }
     ],
     "wof:id":421195021,
-    "wof:lastmodified":1566609553,
+    "wof:lastmodified":1582360299,
     "wof:name":"Villeta",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/195/025/421195025.geojson
+++ b/data/421/195/025/421195025.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ac7b4220fca3576241d80d8216ac63f",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421195025,
-    "wof:lastmodified":1566609551,
+    "wof:lastmodified":1582360298,
     "wof:name":"Yuty",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/421/196/007/421196007.geojson
+++ b/data/421/196/007/421196007.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459009866,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"ec33fc1ecabb12017e98385c7eb867a7",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":421196007,
-    "wof:lastmodified":1534379450,
+    "wof:lastmodified":1582360304,
     "wof:name":"Villa Hayes",
     "wof:parent_id":421171367,
     "wof:placetype":"locality",

--- a/data/421/201/641/421201641.geojson
+++ b/data/421/201/641/421201641.geojson
@@ -244,6 +244,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459010079,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0efb7864e4ff0d35269daa3e779845e",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
         }
     ],
     "wof:id":421201641,
-    "wof:lastmodified":1566609577,
+    "wof:lastmodified":1582360305,
     "wof:name":"Concepcion",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/421/201/649/421201649.geojson
+++ b/data/421/201/649/421201649.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459010079,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72065bfed263612b0dc062dbb3e80db4",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421201649,
-    "wof:lastmodified":1566609576,
+    "wof:lastmodified":1582360304,
     "wof:name":"Valenzuela",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/204/307/421204307.geojson
+++ b/data/421/204/307/421204307.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459010180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6d5e603bffee4bb8b67a1fa42c164e5",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421204307,
-    "wof:lastmodified":1566609557,
+    "wof:lastmodified":1582360300,
     "wof:name":"Jesus",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/204/309/421204309.geojson
+++ b/data/421/204/309/421204309.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459010180,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86ee956c253a98df1bfce5b25abdb924",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421204309,
-    "wof:lastmodified":1566609557,
+    "wof:lastmodified":1582360300,
     "wof:name":"Ayolas",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/205/007/421205007.geojson
+++ b/data/421/205/007/421205007.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"PY",
     "wof:created":1459010209,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1fbda67e1e5575c61f8b3795ea2ec558",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421205007,
-    "wof:lastmodified":1566609559,
+    "wof:lastmodified":1582360301,
     "wof:name":"Villa Oliva",
     "wof:parent_id":1108692791,
     "wof:placetype":"locality",

--- a/data/856/323/55/85632355.geojson
+++ b/data/856/323/55/85632355.geojson
@@ -939,8 +939,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1015,7 +1014,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1582360262,
+    "wof:lastmodified":1583241764,
     "wof:name":"Paraguay",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/323/55/85632355.geojson
+++ b/data/856/323/55/85632355.geojson
@@ -939,7 +939,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -993,6 +994,11 @@
     },
     "wof:country":"PY",
     "wof:country_alpha3":"PRY",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"a38e9993364eee48993ecc6e3d87f157",
     "wof:hierarchy":[
         {
@@ -1009,7 +1015,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609276,
+    "wof:lastmodified":1582360262,
     "wof:name":"Paraguay",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/766/51/85676651.geojson
+++ b/data/856/766/51/85676651.geojson
@@ -581,6 +581,9 @@
         "wd:id":"Q2933"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5322a896d6b3977d5f5e73ea894fc487",
     "wof:hierarchy":[
         {
@@ -598,7 +601,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609297,
+    "wof:lastmodified":1582360275,
     "wof:name":"Asunci\u00f3n",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/55/85676655.geojson
+++ b/data/856/766/55/85676655.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Alto Paraguay Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5710b0083a987b9ec39670c7b3081c04",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609306,
+    "wof:lastmodified":1582360280,
     "wof:name":"Alto Paraguay",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/59/85676659.geojson
+++ b/data/856/766/59/85676659.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Boquer\u00f3n department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec52fe5e9d5c23a14834a21658980728",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609296,
+    "wof:lastmodified":1582360274,
     "wof:name":"Boquer\u00f3n",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/65/85676665.geojson
+++ b/data/856/766/65/85676665.geojson
@@ -257,6 +257,9 @@
         "wk:page":"Concepci\u00f3n Department, Paraguay"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"436e180f51feb12f82d4cd0153511916",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609303,
+    "wof:lastmodified":1582360278,
     "wof:name":"Concepci\u00f3n",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/67/85676667.geojson
+++ b/data/856/766/67/85676667.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Cordillera Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"16af8046d2ec7d595fc07416447242b2",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609297,
+    "wof:lastmodified":1582360275,
     "wof:name":"Cordillera",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/71/85676671.geojson
+++ b/data/856/766/71/85676671.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Presidente Hayes Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a6f2cde350a8e17da05aba0bc4e44f7",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609308,
+    "wof:lastmodified":1582360281,
     "wof:name":"Presidente Hayes",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/75/85676675.geojson
+++ b/data/856/766/75/85676675.geojson
@@ -300,6 +300,9 @@
         "wk:page":"San Pedro Department, Paraguay"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63e1d75bf2da851d4a512967c9be4da2",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609299,
+    "wof:lastmodified":1582360276,
     "wof:name":"San Pedro",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/81/85676681.geojson
+++ b/data/856/766/81/85676681.geojson
@@ -320,6 +320,9 @@
         "wk:page":"Central Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53a8a2746b0991d6172063a0d76fee61",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609301,
+    "wof:lastmodified":1582360277,
     "wof:name":"Central",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/85/85676685.geojson
+++ b/data/856/766/85/85676685.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Guair\u00e1 Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b471f462d1e85565999c8c72b7d5e232",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609306,
+    "wof:lastmodified":1582360280,
     "wof:name":"Guair\u00e1",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/89/85676689.geojson
+++ b/data/856/766/89/85676689.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Misiones Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfef938f5edfad99e1a5675ae5a4281f",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609298,
+    "wof:lastmodified":1582360275,
     "wof:name":"Misiones",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/91/85676691.geojson
+++ b/data/856/766/91/85676691.geojson
@@ -306,6 +306,9 @@
         "wk:page":"\u00d1eembuc\u00fa Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc5e5478180a0f396540088d588eb358",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609302,
+    "wof:lastmodified":1582360277,
     "wof:name":"\u00d1eembuc\u00fa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/99/85676699.geojson
+++ b/data/856/766/99/85676699.geojson
@@ -252,6 +252,9 @@
         "wk:page":"Paraguar\u00ed Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f651a881dea34c0b138467b68b2cfaf",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609304,
+    "wof:lastmodified":1582360279,
     "wof:name":"Paraguar\u00ed",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/01/85676701.geojson
+++ b/data/856/767/01/85676701.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Amambay Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b8963ea4c48d9bd7702fb2e0eec95d1",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609286,
+    "wof:lastmodified":1582360268,
     "wof:name":"Amambay",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/05/85676705.geojson
+++ b/data/856/767/05/85676705.geojson
@@ -318,6 +318,9 @@
         "wk:page":"Alto Paran\u00e1 Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a1c0308c8e890a7fc08cd918629a4c5",
     "wof:hierarchy":[
         {
@@ -335,7 +338,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609278,
+    "wof:lastmodified":1582360263,
     "wof:name":"Alto Paran\u00e1",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/09/85676709.geojson
+++ b/data/856/767/09/85676709.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Caaguaz\u00fa Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63c57be5b3e3f898d6d2aba4bd98f014",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609284,
+    "wof:lastmodified":1582360266,
     "wof:name":"Caaguaz\u00fa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/13/85676713.geojson
+++ b/data/856/767/13/85676713.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Caazap\u00e1 Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1138ab4bff258e8b33fd8a86519bc98b",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609292,
+    "wof:lastmodified":1582360272,
     "wof:name":"Caazap\u00e1",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/19/85676719.geojson
+++ b/data/856/767/19/85676719.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Canindey\u00fa Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc1a397b5b8f64308c119ccda295338c",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609282,
+    "wof:lastmodified":1582360265,
     "wof:name":"Canindey\u00fa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/23/85676723.geojson
+++ b/data/856/767/23/85676723.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Itap\u00faa Department"
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a3fc127ea979a9356030cc59c21f83b",
     "wof:hierarchy":[
         {
@@ -326,7 +329,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1566609289,
+    "wof:lastmodified":1582360270,
     "wof:name":"Itap\u00faa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/857/648/69/85764869.geojson
+++ b/data/857/648/69/85764869.geojson
@@ -80,6 +80,9 @@
         "qs:id":887606
     },
     "wof:country":"PY",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67e0efee6817cab690589cb242d52835",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379451,
+    "wof:lastmodified":1582360260,
     "wof:name":"Banco San Miguel",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/440/117/890440117.geojson
+++ b/data/890/440/117/890440117.geojson
@@ -304,6 +304,9 @@
     },
     "wof:country":"PY",
     "wof:created":1469052263,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2726cc3d13a9c122c8133458b61ba84a",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         }
     ],
     "wof:id":890440117,
-    "wof:lastmodified":1566609608,
+    "wof:lastmodified":1582360318,
     "wof:name":"Concepci\u00f3n",
     "wof:parent_id":421201641,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.