### PR TITLE
py concordances, placetype local, and more

### DIFF
--- a/data/110/869/244/3/1108692443.geojson
+++ b/data/110/869/244/3/1108692443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.324099,
-    "geom:area_square_m":3703254493.123315,
+    "geom:area_square_m":3703255107.591801,
     "geom:bbox":"-56.826067,-22.913499,-56.070409,-22.074456",
     "geom:latitude":-22.470827,
     "geom:longitude":-56.454791,
@@ -148,9 +148,10 @@
         "hasc:id":"PY.AM.BV",
         "wd:id":"Q815785"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325504,
-    "wof:geomhash":"3418f3881a2138c5142f0a2a0724b41c",
+    "wof:geomhash":"2866e780c51f360e59416755509656ea",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108692443,
-    "wof:lastmodified":1690856987,
+    "wof:lastmodified":1695886093,
     "wof:name":"Bella Vista",
     "wof:parent_id":85676701,
     "wof:placetype":"county",

--- a/data/110/869/244/5/1108692445.geojson
+++ b/data/110/869/244/5/1108692445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319401,
-    "geom:area_square_m":3623951092.057446,
+    "geom:area_square_m":3623951401.326708,
     "geom:bbox":"-56.168368,-23.830937,-55.504321,-23.002021",
     "geom:latitude":-23.424184,
     "geom:longitude":-55.812917,
@@ -106,9 +106,10 @@
         "hasc:id":"PY.AM.CB",
         "wd:id":"Q2717429"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325507,
-    "wof:geomhash":"f466d79588fe07f6f598f0dfc5a5c25c",
+    "wof:geomhash":"63a842935f8ccb6a436284894f50791a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108692445,
-    "wof:lastmodified":1690856988,
+    "wof:lastmodified":1695886815,
     "wof:name":"Capitan Bado",
     "wof:parent_id":85676701,
     "wof:placetype":"county",

--- a/data/110/869/244/7/1108692447.geojson
+++ b/data/110/869/244/7/1108692447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046055,
-    "geom:area_square_m":525088930.683311,
+    "geom:area_square_m":525088797.768283,
     "geom:bbox":"-55.857878,-23.018369,-55.609331,-22.605487",
     "geom:latitude":-22.7719,
     "geom:longitude":-55.708776,
@@ -67,9 +67,10 @@
         "hasc:id":"PY.AM.PC",
         "wd:id":"Q17781865"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325508,
-    "wof:geomhash":"764b9885f8c5a7b573a51438ab728d99",
+    "wof:geomhash":"d25d86fe0686ba7d50c900ab7fab277b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108692447,
-    "wof:lastmodified":1690856987,
+    "wof:lastmodified":1695886815,
     "wof:name":"Zanja Pyta",
     "wof:parent_id":85676701,
     "wof:placetype":"county",

--- a/data/110/869/244/9/1108692449.geojson
+++ b/data/110/869/244/9/1108692449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15725,
-    "geom:area_square_m":1773734466.300074,
+    "geom:area_square_m":1773734536.15873,
     "geom:bbox":"-54.732424,-24.537313,-54.258924,-23.812211",
     "geom:latitude":-24.186293,
     "geom:longitude":-54.466611,
@@ -148,9 +148,10 @@
         "hasc:id":"PY.CY.SG",
         "wd:id":"Q135983"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325510,
-    "wof:geomhash":"4b748b5382bff83f47c1b726d32ddc76",
+    "wof:geomhash":"5bb2ae075d7152b2a286511cbbae1781",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":1108692449,
-    "wof:lastmodified":1690856986,
+    "wof:lastmodified":1695886815,
     "wof:name":"Saltos Del Guaira",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/245/1/1108692451.geojson
+++ b/data/110/869/245/1/1108692451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.123377,
-    "geom:area_square_m":1392491788.679404,
+    "geom:area_square_m":1392491953.202454,
     "geom:bbox":"-55.334034,-24.355635,-54.815856,-23.883514",
     "geom:latitude":-24.110466,
     "geom:longitude":-55.009925,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CY.CC",
         "wd:id":"Q3694152"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325511,
-    "wof:geomhash":"9e773249e866b735d08e71c5a9ea5644",
+    "wof:geomhash":"dd6f8157190967e6dad83520c3d3af78",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692451,
-    "wof:lastmodified":1690856985,
+    "wof:lastmodified":1695886814,
     "wof:name":"Corpus Christi",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/245/3/1108692453.geojson
+++ b/data/110/869/245/3/1108692453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264597,
-    "geom:area_square_m":2981061890.939578,
+    "geom:area_square_m":2981061609.165499,
     "geom:bbox":"-56.172538,-24.72135,-55.310341,-24.02007",
     "geom:latitude":-24.336176,
     "geom:longitude":-55.774626,
@@ -106,9 +106,10 @@
         "hasc:id":"PY.CY.VC",
         "wd:id":"Q1093456"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325512,
-    "wof:geomhash":"9aaf6ac216407c5b2f9693b370be65d4",
+    "wof:geomhash":"8a601e85c4483755d406aea0e641a5d4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108692453,
-    "wof:lastmodified":1690856986,
+    "wof:lastmodified":1695886814,
     "wof:name":"Curuguaty",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/245/5/1108692455.geojson
+++ b/data/110/869/245/5/1108692455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180325,
-    "geom:area_square_m":2034855756.158266,
+    "geom:area_square_m":2034855880.174572,
     "geom:bbox":"-55.844269,-24.374104,-55.18414,-23.873069",
     "geom:latitude":-24.133463,
     "geom:longitude":-55.481914,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CY.VY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325513,
-    "wof:geomhash":"1f9374d8324c86debe04a64b7d712442",
+    "wof:geomhash":"d4e9a0eb815696134d4d31d22f734645",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692455,
-    "wof:lastmodified":1627522523,
+    "wof:lastmodified":1695886170,
     "wof:name":"Villa Ygatim\u00cd",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/245/7/1108692457.geojson
+++ b/data/110/869/245/7/1108692457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080239,
-    "geom:area_square_m":908082880.647017,
+    "geom:area_square_m":908082880.646883,
     "geom:bbox":"-56.0272142152,-23.9041563601,-55.412261742,-23.5232921027",
     "geom:latitude":-23.75892,
     "geom:longitude":-55.657629,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CY.IT",
         "wd:id":"Q1986095"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325515,
-    "wof:geomhash":"77b7b6f6c2f008259bbd2dcd33f2fba5",
+    "wof:geomhash":"f23377538181bbb562ec2fbe261567b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692457,
-    "wof:lastmodified":1566609399,
+    "wof:lastmodified":1695886814,
     "wof:name":"Itanara",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/246/1/1108692461.geojson
+++ b/data/110/869/246/1/1108692461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075418,
-    "geom:area_square_m":852405673.697241,
+    "geom:area_square_m":852405324.373863,
     "geom:bbox":"-56.0257,-24.06955,-55.413769,-23.795668",
     "geom:latitude":-23.928064,
     "geom:longitude":-55.767585,
@@ -142,9 +142,10 @@
         "hasc:id":"PY.CY.YP",
         "wd:id":"Q578964"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325516,
-    "wof:geomhash":"a522adfc2c41b43de66e48906a36bc38",
+    "wof:geomhash":"bf8e7aff9747e9bc5820624e1f4d6049",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108692461,
-    "wof:lastmodified":1636503105,
+    "wof:lastmodified":1695886098,
     "wof:name":"Ype Jhu",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/246/3/1108692463.geojson
+++ b/data/110/869/246/3/1108692463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065414,
-    "geom:area_square_m":738023396.252398,
+    "geom:area_square_m":738023333.097876,
     "geom:bbox":"-54.823285,-24.499062,-54.576956,-23.857164",
     "geom:latitude":-24.156535,
     "geom:longitude":-54.711447,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CY.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325517,
-    "wof:geomhash":"6caad641413496e8dff90eed28f5c7c1",
+    "wof:geomhash":"e11accbb70eb6b1e78f351ec28a8d570",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692463,
-    "wof:lastmodified":1627522521,
+    "wof:lastmodified":1695886166,
     "wof:name":"Francisco Caballero Alvarez",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/246/5/1108692465.geojson
+++ b/data/110/869/246/5/1108692465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052105,
-    "geom:area_square_m":587005440.621396,
+    "geom:area_square_m":587005440.621435,
     "geom:bbox":"-54.9619983976,-24.4663576556,-54.6627160278,-24.1513045763",
     "geom:latitude":-24.342898,
     "geom:longitude":-54.792416,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CY.KA",
         "wd:id":"Q1986659"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325518,
-    "wof:geomhash":"f6da3187151112015065d201d8baf592",
+    "wof:geomhash":"8ceeda790458f67a7b7175b14e69f5b5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692465,
-    "wof:lastmodified":1566609476,
+    "wof:lastmodified":1695886831,
     "wof:name":"Katuete",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/246/7/1108692467.geojson
+++ b/data/110/869/246/7/1108692467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056463,
-    "geom:area_square_m":636849349.612145,
+    "geom:area_square_m":636849418.347964,
     "geom:bbox":"-54.706573,-24.401217,-54.412298,-23.962404",
     "geom:latitude":-24.193801,
     "geom:longitude":-54.561997,
@@ -127,9 +127,10 @@
         "hasc:id":"PY.CY.LP",
         "wd:id":"Q893080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325520,
-    "wof:geomhash":"505cbcfb32be9fac2b84004eb344250c",
+    "wof:geomhash":"1840a88b6413eff423e4bd3b6a6686b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692467,
-    "wof:lastmodified":1636503105,
+    "wof:lastmodified":1695886098,
     "wof:name":"La Paloma",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/246/9/1108692469.geojson
+++ b/data/110/869/246/9/1108692469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119628,
-    "geom:area_square_m":1345156841.389048,
+    "geom:area_square_m":1345156841.389202,
     "geom:bbox":"-55.0278339114,-24.7234000534,-54.3165123373,-24.4473227302",
     "geom:latitude":-24.581662,
     "geom:longitude":-54.653881,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CY.NE",
         "wd:id":"Q3879288"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325521,
-    "wof:geomhash":"763022ad29cce6bb8939e99965db922a",
+    "wof:geomhash":"51f5be68b7dfdf7ad96c0127f7b5c8b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692469,
-    "wof:lastmodified":1566609474,
+    "wof:lastmodified":1695886831,
     "wof:name":"Nueva Esperanza",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/247/1/1108692471.geojson
+++ b/data/110/869/247/1/1108692471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067099,
-    "geom:area_square_m":754614795.046993,
+    "geom:area_square_m":754614799.4905,
     "geom:bbox":"-56.059117,-24.78397,-55.701991,-24.366191",
     "geom:latitude":-24.562547,
     "geom:longitude":-55.869795,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CY.VC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325522,
-    "wof:geomhash":"37e8c81a94cca39c3e9c9876826a29ab",
+    "wof:geomhash":"6e08adfcd72ef764324941550907bbbd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108692471,
-    "wof:lastmodified":1627522524,
+    "wof:lastmodified":1695886171,
     "wof:name":"Yasy Kany",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/247/3/1108692473.geojson
+++ b/data/110/869/247/3/1108692473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062596,
-    "geom:area_square_m":688505264.87314,
+    "geom:area_square_m":688505338.789184,
     "geom:bbox":"-56.482484,-27.411052,-56.098127,-27.039449",
     "geom:latitude":-27.186294,
     "geom:longitude":-56.279495,
@@ -139,9 +139,10 @@
         "hasc:id":"PY.IT.CB",
         "wd:id":"Q2443596"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325524,
-    "wof:geomhash":"02a4aad847d5c1cbb7e5d9a179da22fa",
+    "wof:geomhash":"893b60865e8fcfe725ae0710a8a96a4b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108692473,
-    "wof:lastmodified":1690857010,
+    "wof:lastmodified":1695886099,
     "wof:name":"Coronel Bogado",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/247/5/1108692475.geojson
+++ b/data/110/869/247/5/1108692475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084153,
-    "geom:area_square_m":932390273.534176,
+    "geom:area_square_m":932390273.534739,
     "geom:bbox":"-55.212029771,-26.5472098558,-54.6964608255,-26.206021039",
     "geom:latitude":-26.357384,
     "geom:longitude":-54.925699,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.IT.CL",
         "wd:id":"Q3660016"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325525,
-    "wof:geomhash":"5fe7ec590ec4054c322025b245442003",
+    "wof:geomhash":"746fcb916f020ae95ae4903513689447",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692475,
-    "wof:lastmodified":1566609480,
+    "wof:lastmodified":1695886832,
     "wof:name":"Carlos Antonio Lopez",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/247/9/1108692479.geojson
+++ b/data/110/869/247/9/1108692479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034775,
-    "geom:area_square_m":384031246.06688,
+    "geom:area_square_m":384031246.066914,
     "geom:bbox":"-55.2491935048,-26.8789250552,-54.999268586,-26.5992038667",
     "geom:latitude":-26.734358,
     "geom:longitude":-55.139258,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.NT",
         "wd:id":"Q1985044"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325527,
-    "wof:geomhash":"39af923a0baf99723bddbb336e3fad13",
+    "wof:geomhash":"3d209d8db708308bc834d3030b374e2e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692479,
-    "wof:lastmodified":1566609478,
+    "wof:lastmodified":1695886831,
     "wof:name":"Natalio",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/248/1/1108692481.geojson
+++ b/data/110/869/248/1/1108692481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043908,
-    "geom:area_square_m":483849223.971047,
+    "geom:area_square_m":483849223.971036,
     "geom:bbox":"-58.518050208,-27.0608794928,-58.105583683,-26.8924574143",
     "geom:latitude":-26.978268,
     "geom:longitude":-58.317633,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.NE.IU",
         "wd:id":"Q2411034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325528,
-    "wof:geomhash":"371f33caa3eaa103759ac6fe8a985c67",
+    "wof:geomhash":"a7d07f4f5ca0d76b5935046a60620c99",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692481,
-    "wof:lastmodified":1566609464,
+    "wof:lastmodified":1695886828,
     "wof:name":"Isla Umbu",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/248/3/1108692483.geojson
+++ b/data/110/869/248/3/1108692483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052898,
-    "geom:area_square_m":584958067.648534,
+    "geom:area_square_m":584957690.917104,
     "geom:bbox":"-57.119917,-26.711699,-56.802169,-26.419516",
     "geom:latitude":-26.580906,
     "geom:longitude":-56.967654,
@@ -118,9 +118,10 @@
         "hasc:id":"PY.MI.SG",
         "wd:id":"Q3947702"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325529,
-    "wof:geomhash":"38256ca7e6b123b5971083754a25fbf9",
+    "wof:geomhash":"752089697431b4703f76b8f319e60aa3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108692483,
-    "wof:lastmodified":1636503104,
+    "wof:lastmodified":1695886097,
     "wof:name":"San Miguel",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/110/869/248/5/1108692485.geojson
+++ b/data/110/869/248/5/1108692485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097033,
-    "geom:area_square_m":1096053920.235649,
+    "geom:area_square_m":1096053920.235881,
     "geom:bbox":"-56.4719120171,-24.1587803719,-55.9771072191,-23.8215148379",
     "geom:latitude":-24.005178,
     "geom:longitude":-56.20818,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.SP.GR",
         "wd:id":"Q2475348"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325530,
-    "wof:geomhash":"d69fcdcc563ab5eeac31cc53d45e42a6",
+    "wof:geomhash":"4af83873c9ef69cfd1cbde25ebc1b046",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692485,
-    "wof:lastmodified":1566609465,
+    "wof:lastmodified":1695886828,
     "wof:name":"General Resquin",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/248/7/1108692487.geojson
+++ b/data/110/869/248/7/1108692487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030189,
-    "geom:area_square_m":338765186.813105,
+    "geom:area_square_m":338765186.813172,
     "geom:bbox":"-56.4377848838,-24.9412562417,-56.1971632595,-24.7280998273",
     "geom:latitude":-24.83738,
     "geom:longitude":-56.329043,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.SP.YN",
         "wd:id":"Q1988951"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325531,
-    "wof:geomhash":"cf1bbb9bfbf03380792803f0e58269dd",
+    "wof:geomhash":"c671d781e45bd223eccb80de0bdbe96b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692487,
-    "wof:lastmodified":1566609464,
+    "wof:lastmodified":1695886828,
     "wof:name":"Yataity Del Norte",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/248/9/1108692489.geojson
+++ b/data/110/869/248/9/1108692489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101389,
-    "geom:area_square_m":1141650664.278513,
+    "geom:area_square_m":1141650664.278365,
     "geom:bbox":"-56.5560508039,-24.5891369204,-56.1157902186,-24.1946199779",
     "geom:latitude":-24.407866,
     "geom:longitude":-56.34811,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.SP.GU",
         "wd:id":"Q2457120"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325532,
-    "wof:geomhash":"0f23777ac8528bbf6b3d883e1fca48e3",
+    "wof:geomhash":"f4a7325f9ceb391cdb0ae65c4a1ec787",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692489,
-    "wof:lastmodified":1566609463,
+    "wof:lastmodified":1695886828,
     "wof:name":"Guajayvi",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/249/1/1108692491.geojson
+++ b/data/110/869/249/1/1108692491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088416,
-    "geom:area_square_m":992884950.336738,
+    "geom:area_square_m":992885251.482409,
     "geom:bbox":"-56.176524,-24.938538,-55.701991,-24.530899",
     "geom:latitude":-24.745879,
     "geom:longitude":-55.991597,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.SP.CA",
         "wd:id":"Q1989270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325533,
-    "wof:geomhash":"aa9ecd38c4a25715140e002c9629aef1",
+    "wof:geomhash":"b8eb86a26649a1fc768ddc42eb46a668",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692491,
-    "wof:lastmodified":1690857010,
+    "wof:lastmodified":1695886832,
     "wof:name":"Capiibary",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/249/3/1108692493.geojson
+++ b/data/110/869/249/3/1108692493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139306,
-    "geom:area_square_m":1576552695.040089,
+    "geom:area_square_m":1576552538.204426,
     "geom:bbox":"-56.593214,-23.920308,-55.973478,-23.575541",
     "geom:latitude":-23.759056,
     "geom:longitude":-56.27188,
@@ -79,9 +79,10 @@
         "hasc:id":"PY.SP.SR",
         "wd:id":"Q10862956"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325535,
-    "wof:geomhash":"f5c0088621f5ab4cbe3aea0f944d1972",
+    "wof:geomhash":"5110d30af060c7dee0d143d439a15e41",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108692493,
-    "wof:lastmodified":1690857011,
+    "wof:lastmodified":1695886832,
     "wof:name":"Santa Rosa Del Aguaray",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/249/7/1108692497.geojson
+++ b/data/110/869/249/7/1108692497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045396,
-    "geom:area_square_m":510771030.478104,
+    "geom:area_square_m":510771093.59714,
     "geom:bbox":"-56.298438,-24.627847,-55.98717,-24.379704",
     "geom:latitude":-24.504725,
     "geom:longitude":-56.137082,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.SP.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325537,
-    "wof:geomhash":"b7519040fede02295683e6acba4e1528",
+    "wof:geomhash":"5f3ea7d69d3c30d972229015ad3c00e7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692497,
-    "wof:lastmodified":1627522525,
+    "wof:lastmodified":1695886173,
     "wof:name":"Yryvu Cua",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/249/9/1108692499.geojson
+++ b/data/110/869/249/9/1108692499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05253,
-    "geom:area_square_m":592479967.440722,
+    "geom:area_square_m":592480272.319268,
     "geom:bbox":"-56.536191,-24.308341,-56.150125,-24.048718",
     "geom:latitude":-24.196401,
     "geom:longitude":-56.378378,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.SP.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325538,
-    "wof:geomhash":"d3d632b2bd8a27a45c6ac9998a13df8f",
+    "wof:geomhash":"63f7e752306dfb19e37c129cc9c78fd2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692499,
-    "wof:lastmodified":1627522522,
+    "wof:lastmodified":1695886168,
     "wof:name":"Liberacion",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/250/1/1108692501.geojson
+++ b/data/110/869/250/1/1108692501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047901,
-    "geom:area_square_m":536620651.568875,
+    "geom:area_square_m":536620292.943309,
     "geom:bbox":"-57.385737,-25.145304,-56.910611,-24.919144",
     "geom:latitude":-25.042776,
     "geom:longitude":-57.162466,
@@ -115,9 +115,10 @@
         "hasc:id":"PY.CR.AE",
         "wd:id":"Q2639218"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325541,
-    "wof:geomhash":"ae1ffd1b4cbfcb58623baac27569fb44",
+    "wof:geomhash":"923c69a683f7979548b9679e84776a36",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108692501,
-    "wof:lastmodified":1690856994,
+    "wof:lastmodified":1695886819,
     "wof:name":"Arroyos Y Esteros",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/250/3/1108692503.geojson
+++ b/data/110/869/250/3/1108692503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037541,
-    "geom:area_square_m":419973073.294417,
+    "geom:area_square_m":419973073.294479,
     "geom:bbox":"-56.9075124653,-25.3553595917,-56.619033251,-25.1091131896",
     "geom:latitude":-25.215098,
     "geom:longitude":-56.777374,
@@ -103,9 +103,10 @@
         "hasc:id":"PY.CR.CR",
         "wd:id":"Q2639192"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325543,
-    "wof:geomhash":"ff1139d94c50996235e4f8a5974c34b0",
+    "wof:geomhash":"f184c6a0504dfb6380dc200fffebafda",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692503,
-    "wof:lastmodified":1566609429,
+    "wof:lastmodified":1695886819,
     "wof:name":"Caraguatay",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/250/5/1108692505.geojson
+++ b/data/110/869/250/5/1108692505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017076,
-    "geom:area_square_m":191158780.208183,
+    "geom:area_square_m":191158780.208043,
     "geom:bbox":"-57.4783165965,-25.2079748119,-57.2727138547,-25.0616158885",
     "geom:latitude":-25.128833,
     "geom:longitude":-57.362946,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.CR.EM",
         "wd:id":"Q2410997"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325544,
-    "wof:geomhash":"dcdd86dae9c97eae5062ddf96b8b150d",
+    "wof:geomhash":"e6b9f0b86b314326b56f6cd34a618a9f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692505,
-    "wof:lastmodified":1566609430,
+    "wof:lastmodified":1695886820,
     "wof:name":"Emboscada",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/250/7/1108692507.geojson
+++ b/data/110/869/250/7/1108692507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02613,
-    "geom:area_square_m":291963451.490273,
+    "geom:area_square_m":291963553.264129,
     "geom:bbox":"-57.071367,-25.468299,-56.86357,-25.238744",
     "geom:latitude":-25.361194,
     "geom:longitude":-56.971451,
@@ -109,9 +109,10 @@
         "hasc:id":"PY.CR.EU",
         "wd:id":"Q2377309"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325545,
-    "wof:geomhash":"8d831600d784ffe4afda8f96686406b7",
+    "wof:geomhash":"82baf4cc83dd475f006f4d58604526d4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108692507,
-    "wof:lastmodified":1690856994,
+    "wof:lastmodified":1695886819,
     "wof:name":"Eusebio Ayala",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/250/9/1108692509.geojson
+++ b/data/110/869/250/9/1108692509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008173,
-    "geom:area_square_m":91367273.89423,
+    "geom:area_square_m":91367273.894278,
     "geom:bbox":"-56.9461003943,-25.367381286,-56.8314119239,-25.2193169316",
     "geom:latitude":-25.300835,
     "geom:longitude":-56.896097,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CR.IS",
         "wd:id":"Q2410881"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325546,
-    "wof:geomhash":"6e651f77e9342fb1e6113b63000cc0dc",
+    "wof:geomhash":"4e7a4b0a46e691e0177eaa773a6dc0d6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692509,
-    "wof:lastmodified":1566609427,
+    "wof:lastmodified":1695886819,
     "wof:name":"Isla Pucu",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/251/1/1108692511.geojson
+++ b/data/110/869/251/1/1108692511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012531,
-    "geom:area_square_m":139905643.917095,
+    "geom:area_square_m":139905643.917116,
     "geom:bbox":"-56.9471432117,-25.5083765054,-56.7739736392,-25.3607964849",
     "geom:latitude":-25.452271,
     "geom:longitude":-56.864017,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.CR.IC",
         "wd:id":"Q2410979"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325547,
-    "wof:geomhash":"88c3a7e5b9b9b54a41553c350cc438f7",
+    "wof:geomhash":"62719ed6a7cce9075f84d322942977f0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692511,
-    "wof:lastmodified":1566609449,
+    "wof:lastmodified":1695886824,
     "wof:name":"Itacurubi De La Cordillera",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/251/5/1108692515.geojson
+++ b/data/110/869/251/5/1108692515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086862,
-    "geom:area_square_m":973467550.366943,
+    "geom:area_square_m":973467550.367166,
     "geom:bbox":"-57.0534177375,-25.1671113455,-56.5616795726,-24.8432789524",
     "geom:latitude":-24.994954,
     "geom:longitude":-56.772914,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.CR.JM",
         "wd:id":"Q2410295"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325549,
-    "wof:geomhash":"d5902be8b04d5318907c3c7641e26034",
+    "wof:geomhash":"11034e8cfcbb5592fec51116db8dee8b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692515,
-    "wof:lastmodified":1566609450,
+    "wof:lastmodified":1695886825,
     "wof:name":"Juan De Mena",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/251/7/1108692517.geojson
+++ b/data/110/869/251/7/1108692517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007588,
-    "geom:area_square_m":84934774.308278,
+    "geom:area_square_m":84934774.30832,
     "geom:bbox":"-57.2670504848,-25.2134385865,-57.1510081613,-25.0831746251",
     "geom:latitude":-25.148498,
     "geom:longitude":-57.209207,
@@ -103,9 +103,10 @@
         "hasc:id":"PY.CR.LG",
         "wd:id":"Q2411023"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325550,
-    "wof:geomhash":"ad147fe21abfad663601bf4851d90f98",
+    "wof:geomhash":"aba00b3600603837f9d14f338ee03546",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692517,
-    "wof:lastmodified":1566609449,
+    "wof:lastmodified":1695886824,
     "wof:name":"Loma Grande",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/251/9/1108692519.geojson
+++ b/data/110/869/251/9/1108692519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021733,
-    "geom:area_square_m":242920942.652504,
+    "geom:area_square_m":242920942.652549,
     "geom:bbox":"-56.7749497109,-25.435117141,-56.5613616858,-25.1942875889",
     "geom:latitude":-25.319175,
     "geom:longitude":-56.69231,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CR.MY",
         "wd:id":"Q1751170"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325551,
-    "wof:geomhash":"2152e8f6c47a934c65d4bc06a3634b70",
+    "wof:geomhash":"a6d25379aa276b5358deefd669086ece",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692519,
-    "wof:lastmodified":1566609449,
+    "wof:lastmodified":1695886825,
     "wof:name":"Mbocayaty Del Yhaguy",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/252/1/1108692521.geojson
+++ b/data/110/869/252/1/1108692521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007165,
-    "geom:area_square_m":80193221.753615,
+    "geom:area_square_m":80193221.7537,
     "geom:bbox":"-57.3241711221,-25.2314723086,-57.2224318267,-25.0832714629",
     "geom:latitude":-25.159426,
     "geom:longitude":-57.272077,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.CR.NC",
         "wd:id":"Q2410393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325552,
-    "wof:geomhash":"6ee2e424bc49f60bc088f37d48e11807",
+    "wof:geomhash":"980e889dd3892f04d80129b65d67702e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692521,
-    "wof:lastmodified":1566609520,
+    "wof:lastmodified":1695886843,
     "wof:name":"Nueva Colombia",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/252/3/1108692523.geojson
+++ b/data/110/869/252/3/1108692523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007371,
-    "geom:area_square_m":82517684.6819,
+    "geom:area_square_m":82517684.68187,
     "geom:bbox":"-57.0428418568,-25.2117545589,-56.9086398258,-25.0564727246",
     "geom:latitude":-25.127132,
     "geom:longitude":-56.970936,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.CR.PM",
         "wd:id":"Q2411058"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325554,
-    "wof:geomhash":"eb42fe8d6ebbdfc8563dd696507a342c",
+    "wof:geomhash":"255ab757e59085bfdeaecbed02b8f132",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692523,
-    "wof:lastmodified":1566609520,
+    "wof:lastmodified":1695886843,
     "wof:name":"Primero De Marzo",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/252/5/1108692525.geojson
+++ b/data/110/869/252/5/1108692525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011438,
-    "geom:area_square_m":127769102.786307,
+    "geom:area_square_m":127769472.377134,
     "geom:bbox":"-56.860338,-25.4649,-56.721645,-25.327157",
     "geom:latitude":-25.395512,
     "geom:longitude":-56.780626,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.CR.SE",
         "wd:id":"Q1751103"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325555,
-    "wof:geomhash":"fddaf67f6bf684003164b3df7daab24d",
+    "wof:geomhash":"30f09bef6d6953a3d33cf2473c26c6bc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692525,
-    "wof:lastmodified":1690857022,
+    "wof:lastmodified":1695886100,
     "wof:name":"Santa Elena",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/252/7/1108692527.geojson
+++ b/data/110/869/252/7/1108692527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017865,
-    "geom:area_square_m":200016455.005926,
+    "geom:area_square_m":200016455.005989,
     "geom:bbox":"-56.9523876735,-25.2411935815,-56.7508417034,-25.0265937246",
     "geom:latitude":-25.116265,
     "geom:longitude":-56.878371,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CR.SO",
         "wd:id":"Q1750727"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325557,
-    "wof:geomhash":"d22c0299edc94608cb17f5a944bf0ce5",
+    "wof:geomhash":"ff134e2187ff0158a3345a0e86a412f0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692527,
-    "wof:lastmodified":1566609519,
+    "wof:lastmodified":1695886843,
     "wof:name":"San Jose Obrero",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/110/869/252/9/1108692529.geojson
+++ b/data/110/869/252/9/1108692529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039814,
-    "geom:area_square_m":442353514.49578,
+    "geom:area_square_m":442353514.495641,
     "geom:bbox":"-56.7476857553,-26.1973122173,-56.4645261849,-25.8933503418",
     "geom:latitude":-26.034332,
     "geom:longitude":-56.610266,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.GU.BO",
         "wd:id":"Q2409437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325559,
-    "wof:geomhash":"068a007e5fb737c3fe37171090b7b727",
+    "wof:geomhash":"e9bdb314d868a3ea28f1f7e14e60ad4a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692529,
-    "wof:lastmodified":1566609519,
+    "wof:lastmodified":1695886843,
     "wof:name":"Borja",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/253/3/1108692533.geojson
+++ b/data/110/869/253/3/1108692533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015203,
-    "geom:area_square_m":169503967.767698,
+    "geom:area_square_m":169503967.767944,
     "geom:bbox":"-56.3062594805,-25.6758300528,-55.9431382758,-25.5683598681",
     "geom:latitude":-25.621367,
     "geom:longitude":-56.1542,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.GU.CT",
         "wd:id":"Q2412155"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325560,
-    "wof:geomhash":"ecea5901fa43d6d7a3bf1f6d3848d506",
+    "wof:geomhash":"0e43d04093c4226d28fd994dd9394a45",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692533,
-    "wof:lastmodified":1566609498,
+    "wof:lastmodified":1695886836,
     "wof:name":"Mauricio Jose Troche",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/253/5/1108692535.geojson
+++ b/data/110/869/253/5/1108692535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010958,
-    "geom:area_square_m":122047579.026792,
+    "geom:area_square_m":122047579.026783,
     "geom:bbox":"-56.662313735,-25.8089227358,-56.5251697935,-25.6624746887",
     "geom:latitude":-25.742151,
     "geom:longitude":-56.602032,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.GU.CM",
         "wd:id":"Q1005030"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325562,
-    "wof:geomhash":"5c859cd70b0bbd6ebf9b2de7f6fc33f7",
+    "wof:geomhash":"7f3ed518b36eab39899d55cf5c3d001b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692535,
-    "wof:lastmodified":1566609499,
+    "wof:lastmodified":1695886836,
     "wof:name":"Coronel Martinez",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/253/7/1108692537.geojson
+++ b/data/110/869/253/7/1108692537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009343,
-    "geom:area_square_m":104093791.670074,
+    "geom:area_square_m":104093791.670039,
     "geom:bbox":"-56.5844481522,-25.7777625656,-56.474521741,-25.6390485793",
     "geom:latitude":-25.712148,
     "geom:longitude":-56.53142,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.GU.FC",
         "wd:id":"Q3755437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325563,
-    "wof:geomhash":"eef11e70597ced1ef22662207b14f3d5",
+    "wof:geomhash":"79a9f090ada626faea297e10b645bede",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692537,
-    "wof:lastmodified":1566609498,
+    "wof:lastmodified":1695886836,
     "wof:name":"Felix Perez Cardozo",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/253/9/1108692539.geojson
+++ b/data/110/869/253/9/1108692539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044116,
-    "geom:area_square_m":491285893.641793,
+    "geom:area_square_m":491285893.641874,
     "geom:bbox":"-56.3138340112,-25.8663770473,-56.0290722081,-25.6241357114",
     "geom:latitude":-25.761947,
     "geom:longitude":-56.167387,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.GU.IN",
         "wd:id":"Q1661083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325565,
-    "wof:geomhash":"a9cad1cd531fe841c2ff825865efa6fa",
+    "wof:geomhash":"050f4dc51ba6908ee8621a6e79d0462d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692539,
-    "wof:lastmodified":1566609497,
+    "wof:lastmodified":1695886836,
     "wof:name":"Colonia Independencia",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/254/1/1108692541.geojson
+++ b/data/110/869/254/1/1108692541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014401,
-    "geom:area_square_m":160242247.687014,
+    "geom:area_square_m":160242247.687187,
     "geom:bbox":"-56.6339824001,-25.956063991,-56.4947790492,-25.7733820894",
     "geom:latitude":-25.854509,
     "geom:longitude":-56.566783,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.GU.IP",
         "wd:id":"Q2409449"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325566,
-    "wof:geomhash":"68832b2fcf1bd70809217540c52362d5",
+    "wof:geomhash":"4a85b6133fb88f5be5fd15ef954e68cd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692541,
-    "wof:lastmodified":1566609499,
+    "wof:lastmodified":1695886837,
     "wof:name":"Itape",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/254/3/1108692543.geojson
+++ b/data/110/869/254/3/1108692543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029682,
-    "geom:area_square_m":326805359.04387,
+    "geom:area_square_m":326805359.043795,
     "geom:bbox":"-56.1296278939,-27.1911567081,-55.8850800897,-26.9733404586",
     "geom:latitude":-27.074132,
     "geom:longitude":-56.011832,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.FR",
         "wd:id":"Q1440631"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325567,
-    "wof:geomhash":"5f5458128334ba49947c2c2ea4a05da0",
+    "wof:geomhash":"ee27127bd23ff630800ca06b9b7f2c4c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692543,
-    "wof:lastmodified":1566609500,
+    "wof:lastmodified":1695886837,
     "wof:name":"Fram",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/254/5/1108692545.geojson
+++ b/data/110/869/254/5/1108692545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121978,
-    "geom:area_square_m":1345015176.614247,
+    "geom:area_square_m":1345015176.614178,
     "geom:bbox":"-56.6587961654,-27.1122726046,-56.0771691324,-26.7221092922",
     "geom:latitude":-26.905159,
     "geom:longitude":-56.375929,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.IT.GA",
         "wd:id":"Q1417671"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325568,
-    "wof:geomhash":"957c5f32ead49f8017e16a75eef78b1a",
+    "wof:geomhash":"bb717519fc7052f50d22d5f69dfbf1ec",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692545,
-    "wof:lastmodified":1566609501,
+    "wof:lastmodified":1695886837,
     "wof:name":"General Artigas",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/254/7/1108692547.geojson
+++ b/data/110/869/254/7/1108692547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029361,
-    "geom:area_square_m":323171524.575266,
+    "geom:area_square_m":323171524.575365,
     "geom:bbox":"-58.6649122395,-27.1967563927,-58.360949111,-27.0185126322",
     "geom:latitude":-27.109753,
     "geom:longitude":-58.505556,
@@ -112,9 +112,10 @@
         "hasc:id":"PY.NE.HU",
         "wd:id":"Q2039512"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325569,
-    "wof:geomhash":"55791e30ba21c9a9dc87255deba25184",
+    "wof:geomhash":"8943cd480c6a3b350f0ce50add74fd00",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108692547,
-    "wof:lastmodified":1566609499,
+    "wof:lastmodified":1695886837,
     "wof:name":"Humaita",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/255/1/1108692551.geojson
+++ b/data/110/869/255/1/1108692551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023974,
-    "geom:area_square_m":267596721.758667,
+    "geom:area_square_m":267596721.758729,
     "geom:bbox":"-55.3471858048,-25.5897718539,-55.0816136635,-25.3482482473",
     "geom:latitude":-25.48375,
     "geom:longitude":-55.254533,
@@ -172,9 +172,10 @@
         "hasc:id":"PY.AA.DM",
         "wd:id":"Q2445886"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325571,
-    "wof:geomhash":"5e3ee17bd7d8e548392bd0c76a157f73",
+    "wof:geomhash":"b20b635a27463b24c2e14db2d62bdbdc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":1108692551,
-    "wof:lastmodified":1566609517,
+    "wof:lastmodified":1695886842,
     "wof:name":"Dr. Juan Leon Mallorquin",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/255/3/1108692553.geojson
+++ b/data/110/869/255/3/1108692553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175109,
-    "geom:area_square_m":1965337729.386758,
+    "geom:area_square_m":1965337729.387593,
     "geom:bbox":"-55.3500866958,-25.1813471033,-54.9495955801,-24.4762460723",
     "geom:latitude":-24.814184,
     "geom:longitude":-55.152669,
@@ -166,9 +166,10 @@
         "hasc:id":"PY.AA.IT",
         "wd:id":"Q2445898"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325573,
-    "wof:geomhash":"5a2b7a299fe0c9ea4189868e4eb42f90",
+    "wof:geomhash":"c3f65a70241aaf6ff65083b3ae46bda2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108692553,
-    "wof:lastmodified":1566609517,
+    "wof:lastmodified":1695886842,
     "wof:name":"Itakyry",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/255/5/1108692555.geojson
+++ b/data/110/869/255/5/1108692555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020274,
-    "geom:area_square_m":226303767.501298,
+    "geom:area_square_m":226303853.220059,
     "geom:bbox":"-55.426096,-25.629838,-55.305723,-25.33526",
     "geom:latitude":-25.480059,
     "geom:longitude":-55.365111,
@@ -175,9 +175,10 @@
         "hasc:id":"PY.AA.JO",
         "wd:id":"Q2445762"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325574,
-    "wof:geomhash":"b6febf06457fa80f570996dc68ea7557",
+    "wof:geomhash":"316a27a412e34762c989980807e9408c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108692555,
-    "wof:lastmodified":1690857021,
+    "wof:lastmodified":1695886843,
     "wof:name":"Juan E. O\u00b4leary",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/255/7/1108692557.geojson
+++ b/data/110/869/255/7/1108692557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077455,
-    "geom:area_square_m":860300766.249487,
+    "geom:area_square_m":860301127.035412,
     "geom:bbox":"-54.981865,-26.257108,-54.617422,-25.838412",
     "geom:latitude":-26.069493,
     "geom:longitude":-54.781578,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.AA.NC",
         "wd:id":"Q2445774"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325575,
-    "wof:geomhash":"36af603d038f55e676231c397d4be08d",
+    "wof:geomhash":"08339ed0570565d840e924723e534483",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692557,
-    "wof:lastmodified":1690857020,
+    "wof:lastmodified":1695886842,
     "wof:name":"\u00d1acunday",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/255/9/1108692559.geojson
+++ b/data/110/869/255/9/1108692559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043648,
-    "geom:area_square_m":487121487.003514,
+    "geom:area_square_m":487121656.054789,
     "geom:bbox":"-54.956054,-25.653781,-54.720089,-25.356983",
     "geom:latitude":-25.503393,
     "geom:longitude":-54.841465,
@@ -136,9 +136,10 @@
         "hasc:id":"PY.AA.MG",
         "wd:id":"Q650191"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325578,
-    "wof:geomhash":"3b54835514de58fc029d7749d9f8e7fe",
+    "wof:geomhash":"571d23f017966d9736e51502d5a0eebd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1108692559,
-    "wof:lastmodified":1690857020,
+    "wof:lastmodified":1695886842,
     "wof:name":"Minga Guazu",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/256/1/1108692561.geojson
+++ b/data/110/869/256/1/1108692561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08239,
-    "geom:area_square_m":917342339.075787,
+    "geom:area_square_m":917342398.4757,
     "geom:bbox":"-55.55064,-26.035332,-55.213449,-25.52082",
     "geom:latitude":-25.783464,
     "geom:longitude":-55.384826,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.AA.SC",
         "wd:id":"Q2445832"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325579,
-    "wof:geomhash":"ca01f6c2ea5d0fb68fbcb09915639458",
+    "wof:geomhash":"674252bb86fef3592d0bf3d6fb6d29af",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692561,
-    "wof:lastmodified":1636503103,
+    "wof:lastmodified":1695886095,
     "wof:name":"San Cristobal",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/256/3/1108692563.geojson
+++ b/data/110/869/256/3/1108692563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05395,
-    "geom:area_square_m":600733224.532525,
+    "geom:area_square_m":600733378.708338,
     "geom:bbox":"-55.287963,-25.917429,-54.97759,-25.653364",
     "geom:latitude":-25.774664,
     "geom:longitude":-55.136008,
@@ -142,9 +142,10 @@
         "hasc:id":"PY.AA.SR",
         "wd:id":"Q375265"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325580,
-    "wof:geomhash":"dfbd3b8f926889d7784892b41061af3a",
+    "wof:geomhash":"f562cd52cb2d221340bc7a4f36680451",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108692563,
-    "wof:lastmodified":1642551803,
+    "wof:lastmodified":1695886526,
     "wof:name":"Santa Rita",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/256/5/1108692565.geojson
+++ b/data/110/869/256/5/1108692565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057003,
-    "geom:area_square_m":633750489.482062,
+    "geom:area_square_m":633750489.482257,
     "geom:bbox":"-55.4098538589,-26.0959029507,-54.9884785017,-25.780720347",
     "geom:latitude":-25.956623,
     "geom:longitude":-55.203496,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.AA.NR",
         "wd:id":"Q596950"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325582,
-    "wof:geomhash":"42edf4914142d379ee858c4ba551303e",
+    "wof:geomhash":"a6392f79e4299fe34a686760f51a6b6f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692565,
-    "wof:lastmodified":1566609453,
+    "wof:lastmodified":1695886825,
     "wof:name":"Naranjal",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/256/9/1108692569.geojson
+++ b/data/110/869/256/9/1108692569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055992,
-    "geom:area_square_m":623091445.577987,
+    "geom:area_square_m":623091445.577747,
     "geom:bbox":"-55.0628362656,-26.0210668202,-54.799303355,-25.638068802",
     "geom:latitude":-25.845616,
     "geom:longitude":-54.923178,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.AA.SM",
         "wd:id":"Q2445855"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325583,
-    "wof:geomhash":"8d4d2a61aaac89fcbcc88fa8436d33a3",
+    "wof:geomhash":"20b0fee14e8705d05a257d593dcfec01",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692569,
-    "wof:lastmodified":1566609450,
+    "wof:lastmodified":1695886825,
     "wof:name":"Santa Rosa Del Monday",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/257/1/1108692571.geojson
+++ b/data/110/869/257/1/1108692571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078639,
-    "geom:area_square_m":882984012.178871,
+    "geom:area_square_m":882984012.179404,
     "geom:bbox":"-55.0290409532,-24.9438081493,-54.6424875536,-24.5643605096",
     "geom:latitude":-24.762167,
     "geom:longitude":-54.86545,
@@ -166,9 +166,10 @@
         "hasc:id":"PY.AA.MP",
         "wd:id":"Q2445910"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325584,
-    "wof:geomhash":"eb33f561c09bb96a68e50ace3cd1a589",
+    "wof:geomhash":"90b9860554275157723b0b04d3dab75e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108692571,
-    "wof:lastmodified":1566609419,
+    "wof:lastmodified":1695886817,
     "wof:name":"Minga Pora",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/257/3/1108692573.geojson
+++ b/data/110/869/257/3/1108692573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100501,
-    "geom:area_square_m":1126143305.768544,
+    "geom:area_square_m":1126143305.76868,
     "geom:bbox":"-54.9678405839,-25.2533660057,-54.4231385615,-24.8569114978",
     "geom:latitude":-25.015292,
     "geom:longitude":-54.689146,
@@ -163,9 +163,10 @@
         "hasc:id":"PY.AA.MB",
         "wd:id":"Q2445799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325585,
-    "wof:geomhash":"eb494023c581e906e1565a2ed43e7015",
+    "wof:geomhash":"1a62ffdec63b272a6497b71142b30726",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108692573,
-    "wof:lastmodified":1566609421,
+    "wof:lastmodified":1695886818,
     "wof:name":"Mbaracayu",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/257/5/1108692575.geojson
+++ b/data/110/869/257/5/1108692575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091577,
-    "geom:area_square_m":1027540520.013423,
+    "geom:area_square_m":1027540106.868474,
     "geom:bbox":"-55.068402,-25.071751,-54.345807,-24.679505",
     "geom:latitude":-24.848403,
     "geom:longitude":-54.689897,
@@ -175,9 +175,10 @@
         "hasc:id":"PY.AA.SA",
         "wd:id":"Q2445785"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325587,
-    "wof:geomhash":"3a6db31bc36574ab62303888389a9ced",
+    "wof:geomhash":"0499640c896928ec1f9a251e443626d6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108692575,
-    "wof:lastmodified":1690856992,
+    "wof:lastmodified":1695886818,
     "wof:name":"San Alberto",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/257/7/1108692577.geojson
+++ b/data/110/869/257/7/1108692577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048216,
-    "geom:area_square_m":535253232.500249,
+    "geom:area_square_m":535253232.500175,
     "geom:bbox":"-55.2058030199,-26.2432545368,-54.8705678938,-25.9786234372",
     "geom:latitude":-26.132833,
     "geom:longitude":-55.033449,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.AA.NC",
         "wd:id":"Q596950"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325588,
-    "wof:geomhash":"91546a2a7de9dfa399b90f2970c6295e",
+    "wof:geomhash":"9bad04a022cc66c99edd1cb1fc28f42c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692577,
-    "wof:lastmodified":1566609418,
+    "wof:lastmodified":1695886817,
     "wof:name":"Iru\u00f1a",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/257/9/1108692579.geojson
+++ b/data/110/869/257/9/1108692579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072754,
-    "geom:area_square_m":814075153.47104,
+    "geom:area_square_m":814074910.240735,
     "geom:bbox":"-54.874878,-25.342776,-54.417017,-25.067137",
     "geom:latitude":-25.189081,
     "geom:longitude":-54.628335,
@@ -48,10 +48,13 @@
         85676705
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"1020"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"PY",
     "wof:created":1474325589,
-    "wof:geomhash":"cf13483381365c0429e2a8754b051a2d",
+    "wof:geomhash":"94c5b57248d7749f2251d29917c32c8d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":1108692579,
-    "wof:lastmodified":1627522522,
+    "wof:lastmodified":1695886169,
     "wof:name":"Santa Fe Del Parana",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/258/1/1108692581.geojson
+++ b/data/110/869/258/1/1108692581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039206,
-    "geom:area_square_m":437114858.895438,
+    "geom:area_square_m":437114709.516436,
     "geom:bbox":"-55.244114,-25.720778,-54.88236,-25.516707",
     "geom:latitude":-25.624522,
     "geom:longitude":-55.07143,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.AA.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325590,
-    "wof:geomhash":"059484ea3ce2ad0c109cbb8f01c65cd1",
+    "wof:geomhash":"36f26801b9ab51b95d59268d8b6dfa53",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692581,
-    "wof:lastmodified":1642551761,
+    "wof:lastmodified":1695886512,
     "wof:name":"Tavapy",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/258/3/1108692583.geojson
+++ b/data/110/869/258/3/1108692583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021902,
-    "geom:area_square_m":243131081.517472,
+    "geom:area_square_m":243131009.262426,
     "geom:bbox":"-55.322911,-26.244793,-55.129551,-26.014542",
     "geom:latitude":-26.134947,
     "geom:longitude":-55.224891,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"PY.AA.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325591,
-    "wof:geomhash":"df25e2784055e72909c98cd67e5fe46d",
+    "wof:geomhash":"6b8640134b7bf6d2bc224a86163eaac2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108692583,
-    "wof:lastmodified":1627522521,
+    "wof:lastmodified":1695886166,
     "wof:name":"Dr. Raul Pena",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/258/7/1108692587.geojson
+++ b/data/110/869/258/7/1108692587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00186,
-    "geom:area_square_m":20792391.263444,
+    "geom:area_square_m":20792383.680485,
     "geom:bbox":"-57.584936,-25.356956,-57.516422,-25.291726",
     "geom:latitude":-25.327822,
     "geom:longitude":-57.550712,
@@ -205,9 +205,10 @@
         "hasc:id":"PY.CE.FM",
         "wd:id":"Q47062"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325594,
-    "wof:geomhash":"53e021771ac31ed9fd8f27ee0755740b",
+    "wof:geomhash":"4ed416e8e04cb243383c9eca0351b358",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1108692587,
-    "wof:lastmodified":1690857000,
+    "wof:lastmodified":1695886824,
     "wof:name":"Fernando De La Mora",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/258/9/1108692589.geojson
+++ b/data/110/869/258/9/1108692589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002672,
-    "geom:area_square_m":29822673.224178,
+    "geom:area_square_m":29822625.840699,
     "geom:bbox":"-57.485321,-25.527398,-57.422155,-25.456363",
     "geom:latitude":-25.488652,
     "geom:longitude":-57.451822,
@@ -178,9 +178,10 @@
         "hasc:id":"PY.CE.GU",
         "wd:id":"Q2717421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325595,
-    "wof:geomhash":"280e0f419a94c9f63867809f3ccb7044",
+    "wof:geomhash":"8ee72db54d89fe17cd3a5c5d645859d0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":1108692589,
-    "wof:lastmodified":1690857000,
+    "wof:lastmodified":1695886824,
     "wof:name":"Guarambare",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/259/1/1108692591.geojson
+++ b/data/110/869/259/1/1108692591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016422,
-    "geom:area_square_m":183236934.94324,
+    "geom:area_square_m":183236947.246779,
     "geom:bbox":"-57.431337,-25.63998,-57.312051,-25.444545",
     "geom:latitude":-25.529735,
     "geom:longitude":-57.374392,
@@ -190,9 +190,10 @@
         "hasc:id":"PY.CE.IT",
         "wd:id":"Q1093448"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325596,
-    "wof:geomhash":"e2cbe27f21adab6873fc4f66d59d7549",
+    "wof:geomhash":"f1b5eab941003a9340d82b8716413bbb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1108692591,
-    "wof:lastmodified":1690856996,
+    "wof:lastmodified":1695886821,
     "wof:name":"Ita",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/259/3/1108692593.geojson
+++ b/data/110/869/259/3/1108692593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010387,
-    "geom:area_square_m":116022952.64974,
+    "geom:area_square_m":116022859.864506,
     "geom:bbox":"-57.405893,-25.461011,-57.299755,-25.311154",
     "geom:latitude":-25.393597,
     "geom:longitude":-57.353268,
@@ -199,9 +199,10 @@
         "hasc:id":"PY.CE.IG",
         "wd:id":"Q1093634"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325598,
-    "wof:geomhash":"0443e93e947971dbd18c8ae3d4463f28",
+    "wof:geomhash":"c46d185204dcc028859c34ca4965dc53",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1108692593,
-    "wof:lastmodified":1690856997,
+    "wof:lastmodified":1695886821,
     "wof:name":"Itaugua",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/259/5/1108692595.geojson
+++ b/data/110/869/259/5/1108692595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003573,
-    "geom:area_square_m":39973502.465381,
+    "geom:area_square_m":39973588.405988,
     "geom:bbox":"-57.574556,-25.244546,-57.498381,-25.153876",
     "geom:latitude":-25.20126,
     "geom:longitude":-57.531212,
@@ -199,9 +199,10 @@
         "hasc:id":"PY.CE.MA",
         "wd:id":"Q37557"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325601,
-    "wof:geomhash":"0df9587fff8e70733e509886168ff8b2",
+    "wof:geomhash":"4cbf67cb1397de972d4d9d028a84d92a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -211,7 +212,7 @@
         }
     ],
     "wof:id":1108692595,
-    "wof:lastmodified":1690856997,
+    "wof:lastmodified":1695886821,
     "wof:name":"Mariano Roque Alonso",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/259/7/1108692597.geojson
+++ b/data/110/869/259/7/1108692597.geojson
@@ -175,9 +175,10 @@
         "hasc:id":"PY.CE.NI",
         "wd:id":"Q2453244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325602,
-    "wof:geomhash":"68203cae8c0f54051ca9b2e12fe8c9e7",
+    "wof:geomhash":"0ef10baae9cae3972dcebf6512321aca",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108692597,
-    "wof:lastmodified":1566609434,
+    "wof:lastmodified":1695886821,
     "wof:name":"Nueva Italia",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/259/9/1108692599.geojson
+++ b/data/110/869/259/9/1108692599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002602,
-    "geom:area_square_m":29064245.281543,
+    "geom:area_square_m":29064239.152145,
     "geom:bbox":"-57.572458,-25.443768,-57.506093,-25.360923",
     "geom:latitude":-25.396964,
     "geom:longitude":-57.537739,
@@ -205,9 +205,10 @@
         "hasc:id":"PY.CE.NE",
         "wd:id":"Q47056"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325603,
-    "wof:geomhash":"b2afb7b0a5c352eba533c5e3909510ba",
+    "wof:geomhash":"8f56e14dd1824def8a89a26fff4eb4c7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1108692599,
-    "wof:lastmodified":1690856996,
+    "wof:lastmodified":1695886821,
     "wof:name":"\u00d1emby",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/260/1/1108692601.geojson
+++ b/data/110/869/260/1/1108692601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022813,
-    "geom:area_square_m":253378815.570893,
+    "geom:area_square_m":253378815.570476,
     "geom:bbox":"-56.6157982479,-26.1918404384,-56.2743121888,-25.9386828257",
     "geom:latitude":-26.072284,
     "geom:longitude":-56.471033,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.GU.IB",
         "wd:id":"Q2718422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325604,
-    "wof:geomhash":"4c0275cb7ebc3af3ded1b756929e3fc0",
+    "wof:geomhash":"b500fbe868d7c8991af75df528d06606",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692601,
-    "wof:lastmodified":1566609441,
+    "wof:lastmodified":1695886822,
     "wof:name":"Iturbe",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/260/5/1108692605.geojson
+++ b/data/110/869/260/5/1108692605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010198,
-    "geom:area_square_m":113406863.577702,
+    "geom:area_square_m":113406863.577715,
     "geom:bbox":"-56.1568319827,-26.0273961776,-56.0097615968,-25.86215656",
     "geom:latitude":-25.928498,
     "geom:longitude":-56.093845,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.GU.JF",
         "wd:id":"Q1754358"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325605,
-    "wof:geomhash":"e9a7cc6f4c6c8b062444e16b712c6577",
+    "wof:geomhash":"e2cff0ffc40673603d07bc3b26fa1651",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692605,
-    "wof:lastmodified":1566609441,
+    "wof:lastmodified":1695886822,
     "wof:name":"Jose Fassardi",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/260/7/1108692607.geojson
+++ b/data/110/869/260/7/1108692607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005723,
-    "geom:area_square_m":63786387.498938,
+    "geom:area_square_m":63786387.498985,
     "geom:bbox":"-56.3413086449,-25.7102534648,-56.2377106713,-25.6203204031",
     "geom:latitude":-25.664389,
     "geom:longitude":-56.284461,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.GU.NT",
         "wd:id":"Q1752721"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325607,
-    "wof:geomhash":"99d1363efae3c670985260335d152d0c",
+    "wof:geomhash":"e04cddfc5f2c1d823dc4b9f78c44b61b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692607,
-    "wof:lastmodified":1566609440,
+    "wof:lastmodified":1695886822,
     "wof:name":"Natalicio Talavera",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/260/9/1108692609.geojson
+++ b/data/110/869/260/9/1108692609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008129,
-    "geom:area_square_m":90409216.587181,
+    "geom:area_square_m":90409216.587132,
     "geom:bbox":"-56.3719851583,-25.9716713462,-56.2490852438,-25.8448225721",
     "geom:latitude":-25.916642,
     "geom:longitude":-56.314387,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.GU.NU",
         "wd:id":"Q2410962"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325608,
-    "wof:geomhash":"6d2e2d8c74ef5e458343e09000963ad1",
+    "wof:geomhash":"24851f8bcb6cf934f889227c124281b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692609,
-    "wof:lastmodified":1566609440,
+    "wof:lastmodified":1695886822,
     "wof:name":"\u00d1umi",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/261/1/1108692611.geojson
+++ b/data/110/869/261/1/1108692611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01386,
-    "geom:area_square_m":154087137.441015,
+    "geom:area_square_m":154087042.109606,
     "geom:bbox":"-56.494253,-26.039072,-56.349401,-25.879995",
     "geom:latitude":-25.957653,
     "geom:longitude":-56.426838,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.GU.SS",
         "wd:id":"Q2411018"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325609,
-    "wof:geomhash":"486c2e1df713c8666e0ae694169f2c41",
+    "wof:geomhash":"da0a25897dc246bbfe1742bdc66a9e15",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692611,
-    "wof:lastmodified":1636503102,
+    "wof:lastmodified":1695886094,
     "wof:name":"San Salvador",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/261/3/1108692613.geojson
+++ b/data/110/869/261/3/1108692613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008029,
-    "geom:area_square_m":89488114.826303,
+    "geom:area_square_m":89488114.826279,
     "geom:bbox":"-56.5505142188,-25.7310809888,-56.4229277979,-25.6210264125",
     "geom:latitude":-25.666246,
     "geom:longitude":-56.475346,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.GU.YG",
         "wd:id":"Q960280"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325611,
-    "wof:geomhash":"e6f73159049f8bcce6cf9e4421a183e6",
+    "wof:geomhash":"64f34c685d1a0bc6eb89fbb6b5a52bdf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692613,
-    "wof:lastmodified":1566609438,
+    "wof:lastmodified":1695886822,
     "wof:name":"Yataity",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/261/5/1108692615.geojson
+++ b/data/110/869/261/5/1108692615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006792,
-    "geom:area_square_m":75739650.988995,
+    "geom:area_square_m":75739650.988903,
     "geom:bbox":"-56.4439618788,-25.6339215323,-56.3025150181,-25.5647764285",
     "geom:latitude":-25.600861,
     "geom:longitude":-56.363792,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.GU.DB",
         "wd:id":"Q3712443"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325612,
-    "wof:geomhash":"bfd2d3d7d25a7b234d09d92db8f99ac9",
+    "wof:geomhash":"8617185cf13729f165e822c720f98c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692615,
-    "wof:lastmodified":1566609439,
+    "wof:lastmodified":1695886822,
     "wof:name":"Dr. Bottrell",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/261/7/1108692617.geojson
+++ b/data/110/869/261/7/1108692617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059605,
-    "geom:area_square_m":663894533.775376,
+    "geom:area_square_m":663894533.775484,
     "geom:bbox":"-56.11875073,-25.8775854175,-55.633413745,-25.6268371628",
     "geom:latitude":-25.739173,
     "geom:longitude":-55.913258,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.GU.PY",
         "wd:id":"Q2408786"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325613,
-    "wof:geomhash":"2ad0279a6bec11b36f1f99ceb030606c",
+    "wof:geomhash":"b048f355173116eb75e1db65d06c32fa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692617,
-    "wof:lastmodified":1566609437,
+    "wof:lastmodified":1695886821,
     "wof:name":"Paso Yobai",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/261/9/1108692619.geojson
+++ b/data/110/869/261/9/1108692619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006794,
-    "geom:area_square_m":75630858.673223,
+    "geom:area_square_m":75630808.554657,
     "geom:bbox":"-56.689541,-25.887914,-56.617596,-25.700086",
     "geom:latitude":-25.798569,
     "geom:longitude":-56.654138,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.GU.CM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325614,
-    "wof:geomhash":"b9d7fbf7c16bc15b18290a19dac2de92",
+    "wof:geomhash":"591618712b36365da02c930416106c80",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692619,
-    "wof:lastmodified":1627522523,
+    "wof:lastmodified":1695886170,
     "wof:name":"Tebicuary",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/110/869/262/3/1108692623.geojson
+++ b/data/110/869/262/3/1108692623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081587,
-    "geom:area_square_m":912920669.545133,
+    "geom:area_square_m":912921145.562491,
     "geom:bbox":"-56.564242,-25.349054,-56.058441,-25.010675",
     "geom:latitude":-25.187479,
     "geom:longitude":-56.329036,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CG.CR",
         "wd:id":"Q1751129"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325618,
-    "wof:geomhash":"33d1c0ba176a25acbbbdd41d6c897f71",
+    "wof:geomhash":"4ad2dd56074ecc93d2933b40cc534d5d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692623,
-    "wof:lastmodified":1690857017,
+    "wof:lastmodified":1695886838,
     "wof:name":"Carayao",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/262/5/1108692625.geojson
+++ b/data/110/869/262/5/1108692625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011333,
-    "geom:area_square_m":126911741.175219,
+    "geom:area_square_m":126911807.99638,
     "geom:bbox":"-56.318141,-25.14076,-56.130938,-25.030934",
     "geom:latitude":-25.08912,
     "geom:longitude":-56.230851,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CG.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325620,
-    "wof:geomhash":"65724a0c09f778bf75e5f0f3fa4fb1a6",
+    "wof:geomhash":"943ce513b25002b8388b74a067aa66f7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692625,
-    "wof:lastmodified":1627522521,
+    "wof:lastmodified":1695886167,
     "wof:name":"Cecilio Baez",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/262/7/1108692627.geojson
+++ b/data/110/869/262/7/1108692627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004861,
-    "geom:area_square_m":54320407.015687,
+    "geom:area_square_m":54320404.053769,
     "geom:bbox":"-57.570281,-25.402704,-57.463867,-25.295786",
     "geom:latitude":-25.350719,
     "geom:longitude":-57.510937,
@@ -247,9 +247,10 @@
         "hasc:id":"PY.CE.SL",
         "wd:id":"Q938739"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325621,
-    "wof:geomhash":"f8232f1a4e7d2c581aa0e952f796fa2f",
+    "wof:geomhash":"3769092abe079785f82cd478330d5b79",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -259,7 +260,7 @@
         }
     ],
     "wof:id":1108692627,
-    "wof:lastmodified":1690857016,
+    "wof:lastmodified":1695886527,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/262/9/1108692629.geojson
+++ b/data/110/869/262/9/1108692629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027424,
-    "geom:area_square_m":307494254.267707,
+    "geom:area_square_m":307494254.267874,
     "geom:bbox":"-56.4277453074,-25.0173582473,-56.0930040799,-24.7661725677",
     "geom:latitude":-24.932607,
     "geom:longitude":-56.253577,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.CG.SM",
         "wd:id":"Q1751124"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325622,
-    "wof:geomhash":"f5342c39c7165fd12a0d9d6e4c73d929",
+    "wof:geomhash":"d8c59c8111738205c3bc27d50fd76cd6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692629,
-    "wof:lastmodified":1566609502,
+    "wof:lastmodified":1695886837,
     "wof:name":"Santa Rosa Del Mbutuy",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/263/1/1108692631.geojson
+++ b/data/110/869/263/1/1108692631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049604,
-    "geom:area_square_m":554248060.150389,
+    "geom:area_square_m":554248060.149655,
     "geom:bbox":"-55.982742223,-25.5172825564,-55.6628940452,-25.2092335691",
     "geom:latitude":-25.362111,
     "geom:longitude":-55.821632,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CG.DF",
         "wd:id":"Q3712450"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325623,
-    "wof:geomhash":"d3d28a71727a95085e7bddfe16d77174",
+    "wof:geomhash":"903518d39103c1742f08c5691dd84817",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692631,
-    "wof:lastmodified":1566609511,
+    "wof:lastmodified":1695886840,
     "wof:name":"Dr. Juan Manuel Frutos",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/263/3/1108692633.geojson
+++ b/data/110/869/263/3/1108692633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077159,
-    "geom:area_square_m":860540358.446013,
+    "geom:area_square_m":860540358.445489,
     "geom:bbox":"-56.1337260896,-25.6947456476,-55.5134412367,-25.4786420479",
     "geom:latitude":-25.583951,
     "geom:longitude":-55.803085,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CG.RE",
         "wd:id":"Q1751115"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325626,
-    "wof:geomhash":"1c98695f0178937713be04c8d4ac7db4",
+    "wof:geomhash":"faa9764164e102cf71fa4cf961051adf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692633,
-    "wof:lastmodified":1566609514,
+    "wof:lastmodified":1695886841,
     "wof:name":"Repatriacion",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/263/5/1108692635.geojson
+++ b/data/110/869/263/5/1108692635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020756,
-    "geom:area_square_m":231806330.323265,
+    "geom:area_square_m":231806377.636643,
     "geom:bbox":"-56.652202,-25.544098,-56.501546,-25.303842",
     "geom:latitude":-25.419991,
     "geom:longitude":-56.566049,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.CG.NL",
         "wd:id":"Q2407932"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325627,
-    "wof:geomhash":"89e65bb9b6d32cbeaed67af49dbb09ed",
+    "wof:geomhash":"a80aef942f51bb8a6629cc577a9ebab2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692635,
-    "wof:lastmodified":1690857020,
+    "wof:lastmodified":1695886842,
     "wof:name":"Nueva Londres",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/263/7/1108692637.geojson
+++ b/data/110/869/263/7/1108692637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041759,
-    "geom:area_square_m":467804323.624229,
+    "geom:area_square_m":467804260.273254,
     "geom:bbox":"-56.156118,-25.209315,-55.949566,-24.888207",
     "geom:latitude":-25.044907,
     "geom:longitude":-56.050252,
@@ -121,9 +121,10 @@
         "hasc:id":"PY.CG.SJ",
         "wd:id":"Q2410938"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325628,
-    "wof:geomhash":"b84deed68873fed285944d53c222373e",
+    "wof:geomhash":"138d6d102e4acac68374bbf986f8a534",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692637,
-    "wof:lastmodified":1690857019,
+    "wof:lastmodified":1695886514,
     "wof:name":"San Joaquin",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/264/1/1108692641.geojson
+++ b/data/110/869/264/1/1108692641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045056,
-    "geom:area_square_m":502692999.7253,
+    "geom:area_square_m":502692999.72551,
     "geom:bbox":"-56.8564438973,-25.7022731181,-56.5593348659,-25.3975327489",
     "geom:latitude":-25.539431,
     "geom:longitude":-56.698615,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CG.SA",
         "wd:id":"Q2406025"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325629,
-    "wof:geomhash":"b37716e10b1a63b46ca38ac95a68b9a8",
+    "wof:geomhash":"23f0be137b03a6d2dd1222fdc7cbaede",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692641,
-    "wof:lastmodified":1566609508,
+    "wof:lastmodified":1695886839,
     "wof:name":"San Jose De Los Arroyos",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/264/3/1108692643.geojson
+++ b/data/110/869/264/3/1108692643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126436,
-    "geom:area_square_m":1417937695.810706,
+    "geom:area_square_m":1417937695.810389,
     "geom:bbox":"-56.0241336909,-25.2145664585,-55.3756034267,-24.6024170306",
     "geom:latitude":-24.911842,
     "geom:longitude":-55.74918,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CG.YH",
         "wd:id":"Q1751168"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325631,
-    "wof:geomhash":"cdd011f854802e43b94eab783d3d1db9",
+    "wof:geomhash":"9ff1f0517f4c7e23e2ed98529b06b47f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692643,
-    "wof:lastmodified":1566609509,
+    "wof:lastmodified":1695886839,
     "wof:name":"Yhu",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/264/5/1108692645.geojson
+++ b/data/110/869/264/5/1108692645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056441,
-    "geom:area_square_m":630427396.072107,
+    "geom:area_square_m":630427064.616047,
     "geom:bbox":"-55.733103,-25.566371,-55.476412,-25.26182",
     "geom:latitude":-25.402858,
     "geom:longitude":-55.594056,
@@ -106,9 +106,10 @@
         "hasc:id":"PY.CG.DE",
         "wd:id":"Q2406918"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325632,
-    "wof:geomhash":"efd7b2d78d967e983e807b217622e25b",
+    "wof:geomhash":"6810a9fcfa4668218440c97a18cff57f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108692645,
-    "wof:lastmodified":1690857018,
+    "wof:lastmodified":1695886839,
     "wof:name":"J Eulogio Estigarribia",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/264/7/1108692647.geojson
+++ b/data/110/869/264/7/1108692647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028698,
-    "geom:area_square_m":320680269.551094,
+    "geom:area_square_m":320680252.363175,
     "geom:bbox":"-56.386505,-25.425176,-56.087257,-25.26663",
     "geom:latitude":-25.353605,
     "geom:longitude":-56.219781,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CG.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325634,
-    "wof:geomhash":"d4591ef9025dd159687922bd7813f2df",
+    "wof:geomhash":"2d0b852f4b8c846d29e643d66fe4e8d3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692647,
-    "wof:lastmodified":1642551754,
+    "wof:lastmodified":1695886510,
     "wof:name":"R.i. 3 Corrales",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/264/9/1108692649.geojson
+++ b/data/110/869/264/9/1108692649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055976,
-    "geom:area_square_m":626513571.946211,
+    "geom:area_square_m":626513571.946202,
     "geom:bbox":"-55.7291105328,-25.2771014118,-55.3630745389,-25.0111971984",
     "geom:latitude":-25.15375,
     "geom:longitude":-55.575474,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.CG.RO",
         "wd:id":"Q1751791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325635,
-    "wof:geomhash":"56555b10bdb06bdbff4f56e9ea943c71",
+    "wof:geomhash":"aac28c7377e0268b507f7e9c8a3538d2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692649,
-    "wof:lastmodified":1566609507,
+    "wof:lastmodified":1695886838,
     "wof:name":"Raul Arsenio Oviedo",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/265/1/1108692651.geojson
+++ b/data/110/869/265/1/1108692651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013791,
-    "geom:area_square_m":153989652.922768,
+    "geom:area_square_m":153989652.922535,
     "geom:bbox":"-55.4810621253,-25.5575417577,-55.3784357075,-25.3551054391",
     "geom:latitude":-25.44037,
     "geom:longitude":-55.437636,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CG.JO",
         "wd:id":"Q3810432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325636,
-    "wof:geomhash":"87d64544a351efe25f0fa19d957fc2ad",
+    "wof:geomhash":"e9a07d52a25894038533fac26f5b41fb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692651,
-    "wof:lastmodified":1566609505,
+    "wof:lastmodified":1695886838,
     "wof:name":"Jose Domingo Ocampos",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/265/3/1108692653.geojson
+++ b/data/110/869/265/3/1108692653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077959,
-    "geom:area_square_m":872379572.468227,
+    "geom:area_square_m":872379572.467469,
     "geom:bbox":"-55.4223872474,-25.3875183829,-54.9232269419,-24.9907624128",
     "geom:latitude":-25.179476,
     "geom:longitude":-55.180127,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.CG.ML",
         "wd:id":"Q3849345"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325637,
-    "wof:geomhash":"80bf1aa81567e47570df4a334bbde5d5",
+    "wof:geomhash":"da088b13f2731569dda055ec666aae60",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692653,
-    "wof:lastmodified":1566609505,
+    "wof:lastmodified":1695886838,
     "wof:name":"Mariscal Francisco Solano Lope",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/265/5/1108692655.geojson
+++ b/data/110/869/265/5/1108692655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028437,
-    "geom:area_square_m":318035987.735695,
+    "geom:area_square_m":318035987.735724,
     "geom:bbox":"-56.6641434268,-25.3858892966,-56.4377939303,-25.1646178253",
     "geom:latitude":-25.250797,
     "geom:longitude":-56.550204,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CG.LP",
         "wd:id":"Q1751637"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325638,
-    "wof:geomhash":"0846edafbc96716307922c0487e687ad",
+    "wof:geomhash":"c1e8144514e3d76b3bc087effdfffbf6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692655,
-    "wof:lastmodified":1566609506,
+    "wof:lastmodified":1695886838,
     "wof:name":"La Pastora",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/265/9/1108692659.geojson
+++ b/data/110/869/265/9/1108692659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021016,
-    "geom:area_square_m":235109900.319991,
+    "geom:area_square_m":235110014.670238,
     "geom:bbox":"-55.940699,-25.281939,-55.688051,-25.136002",
     "geom:latitude":-25.212614,
     "geom:longitude":-55.808083,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CG.TF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325639,
-    "wof:geomhash":"e942a578fe210269585178402be75edf",
+    "wof:geomhash":"f7cf6d73b4c9742d566039f8ec3ef13e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692659,
-    "wof:lastmodified":1627522519,
+    "wof:lastmodified":1695886163,
     "wof:name":"3 De Febrero",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/266/1/1108692661.geojson
+++ b/data/110/869/266/1/1108692661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031219,
-    "geom:area_square_m":349765254.646504,
+    "geom:area_square_m":349765254.646835,
     "geom:bbox":"-56.5644844768,-25.1417683676,-56.1419538719,-24.9444276385",
     "geom:latitude":-25.033191,
     "geom:longitude":-56.349587,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.CG.SB",
         "wd:id":"Q3961343"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325641,
-    "wof:geomhash":"4bfd2eef164d17a67daaf3703746f9a9",
+    "wof:geomhash":"502575c30244b9560e198cdbc30001a6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692661,
-    "wof:lastmodified":1566609431,
+    "wof:lastmodified":1695886820,
     "wof:name":"Simon Bolivar",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/266/3/1108692663.geojson
+++ b/data/110/869/266/3/1108692663.geojson
@@ -91,6 +91,7 @@
         "hasc:id":"PY.CG.VA",
         "wd:id":"Q1751136"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325642,
     "wof:geomhash":"12696246c174251864f7999e9de5eae6",
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692663,
-    "wof:lastmodified":1694639681,
+    "wof:lastmodified":1695886820,
     "wof:name":"Vaquer\u00eda",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/266/5/1108692665.geojson
+++ b/data/110/869/266/5/1108692665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016856,
-    "geom:area_square_m":185672606.884718,
+    "geom:area_square_m":185672345.044859,
     "geom:bbox":"-55.888504,-27.167663,-55.561883,-26.860381",
     "geom:latitude":-27.021066,
     "geom:longitude":-55.7154,
@@ -142,9 +142,10 @@
         "hasc:id":"PY.IT.HO",
         "wd:id":"Q1984240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325644,
-    "wof:geomhash":"7ee69f4628f4a988c80a0928a4b648c1",
+    "wof:geomhash":"c0ef728c9620d769b9addbd1964d6a0f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108692665,
-    "wof:lastmodified":1690856996,
+    "wof:lastmodified":1695886095,
     "wof:name":"Hohenau",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/266/7/1108692667.geojson
+++ b/data/110/869/266/7/1108692667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011475,
-    "geom:area_square_m":126705971.283502,
+    "geom:area_square_m":126705971.283476,
     "geom:bbox":"-56.3140839738,-26.8069760458,-56.1394152937,-26.6939377512",
     "geom:latitude":-26.747756,
     "geom:longitude":-56.229119,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.IT.JO",
         "wd:id":"Q431581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325646,
-    "wof:geomhash":"10427287c94ea24e39f15dfab6115a7f",
+    "wof:geomhash":"e1cc550df0090a5b4ce63f2af0d54b0e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692667,
-    "wof:lastmodified":1566609430,
+    "wof:lastmodified":1695886820,
     "wof:name":"Leandro Oviedo",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/266/9/1108692669.geojson
+++ b/data/110/869/266/9/1108692669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038516,
-    "geom:area_square_m":424642129.669907,
+    "geom:area_square_m":424642129.66986,
     "geom:bbox":"-55.8686347837,-27.1256349463,-55.5319184733,-26.7730159865",
     "geom:latitude":-26.921831,
     "geom:longitude":-55.708388,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.IT.OB",
         "wd:id":"Q375095"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325647,
-    "wof:geomhash":"11a18ddd2d203b1dd91c21ac2da2e218",
+    "wof:geomhash":"6904499f36311ef1fcaf8c61a64555a4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692669,
-    "wof:lastmodified":1566609430,
+    "wof:lastmodified":1695886820,
     "wof:name":"Obligado",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/267/1/1108692671.geojson
+++ b/data/110/869/267/1/1108692671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025069,
-    "geom:area_square_m":277949715.842884,
+    "geom:area_square_m":277949715.842822,
     "geom:bbox":"-54.9196642962,-26.404360765,-54.6481605276,-26.1741943346",
     "geom:latitude":-26.278434,
     "geom:longitude":-54.768846,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.IT.MO",
         "wd:id":"Q1914490"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325648,
-    "wof:geomhash":"fb9e8c4608c4076018f80ab43e234fd2",
+    "wof:geomhash":"0cb06c43259d9a86ce2de14214808ded",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692671,
-    "wof:lastmodified":1566609444,
+    "wof:lastmodified":1695886823,
     "wof:name":"Mayor Ota\u00d1o",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/267/3/1108692673.geojson
+++ b/data/110/869/267/3/1108692673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136808,
-    "geom:area_square_m":1510873562.980922,
+    "geom:area_square_m":1510873562.981225,
     "geom:bbox":"-56.2554314617,-26.9896022095,-55.7834286967,-26.4565256938",
     "geom:latitude":-26.730107,
     "geom:longitude":-56.008579,
@@ -100,9 +100,10 @@
         "hasc:id":"PY.IT.SP",
         "wd:id":"Q2445863"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325650,
-    "wof:geomhash":"faa957f11b0fec38fa9a6e2bcb51953f",
+    "wof:geomhash":"a9aabc751c9cc803184bf302ade4f78b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108692673,
-    "wof:lastmodified":1566609445,
+    "wof:lastmodified":1695886824,
     "wof:name":"San Pedro Del Parana",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/267/7/1108692677.geojson
+++ b/data/110/869/267/7/1108692677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113533,
-    "geom:area_square_m":1257021921.412131,
+    "geom:area_square_m":1257021921.412421,
     "geom:bbox":"-55.452104409,-26.7041833508,-54.7837283604,-26.0921620694",
     "geom:latitude":-26.439679,
     "geom:longitude":-55.100627,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.SR",
         "wd:id":"Q1985050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325652,
-    "wof:geomhash":"2c334c6264bac96aa72070295b3a2ef5",
+    "wof:geomhash":"997bced0b413ab26aadbcac5318d4c30",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692677,
-    "wof:lastmodified":1566609443,
+    "wof:lastmodified":1695886823,
     "wof:name":"San Rafael Del Parana",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/267/9/1108692679.geojson
+++ b/data/110/869/267/9/1108692679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058125,
-    "geom:area_square_m":642764300.632087,
+    "geom:area_square_m":642764373.85317,
     "geom:bbox":"-55.539821,-26.783764,-55.190789,-26.350111",
     "geom:latitude":-26.580815,
     "geom:longitude":-55.381985,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.IT.ED",
         "wd:id":"Q1985377"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325654,
-    "wof:geomhash":"be3068d2e20548c405ec462882c995b8",
+    "wof:geomhash":"360fdae7fc6156c9dc25e596aa96f4b7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692679,
-    "wof:lastmodified":1690856999,
+    "wof:lastmodified":1695886822,
     "wof:name":"Edelira",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/268/1/1108692681.geojson
+++ b/data/110/869/268/1/1108692681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055334,
-    "geom:area_square_m":612469732.971981,
+    "geom:area_square_m":612469732.97205,
     "geom:bbox":"-55.5131372636,-26.624956492,-55.0836882911,-26.3071007054",
     "geom:latitude":-26.473468,
     "geom:longitude":-55.282483,
@@ -82,9 +82,10 @@
         "hasc:id":"PY.IT.TP",
         "wd:id":"Q369121"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325655,
-    "wof:geomhash":"ee2eb2ef72c54ac9cd9ac1d828ab4774",
+    "wof:geomhash":"359266b3dfb17724489aea055184554b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108692681,
-    "wof:lastmodified":1566609423,
+    "wof:lastmodified":1695886818,
     "wof:name":"Tomas Romero Pereira",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/268/3/1108692683.geojson
+++ b/data/110/869/268/3/1108692683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022216,
-    "geom:area_square_m":244806949.204692,
+    "geom:area_square_m":244806930.153713,
     "geom:bbox":"-56.023823,-27.081464,-55.791817,-26.891323",
     "geom:latitude":-26.977913,
     "geom:longitude":-55.89728,
@@ -127,9 +127,10 @@
         "hasc:id":"PY.IT.LP",
         "wd:id":"Q1799007"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325657,
-    "wof:geomhash":"ecd4a2d9363b8f7b05a12f6dc53ec710",
+    "wof:geomhash":"8559ee06313520e1eecd40f6ac6ef519",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692683,
-    "wof:lastmodified":1690856993,
+    "wof:lastmodified":1695886522,
     "wof:name":"La Paz",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/268/5/1108692685.geojson
+++ b/data/110/869/268/5/1108692685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020523,
-    "geom:area_square_m":226763181.273707,
+    "geom:area_square_m":226763181.273533,
     "geom:bbox":"-55.2155599386,-26.7907095173,-54.9435612373,-26.5691204308",
     "geom:latitude":-26.671862,
     "geom:longitude":-55.051767,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.IT.YA",
         "wd:id":"Q771945"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325658,
-    "wof:geomhash":"8daaee50db9caa5b9ea1c0b5c91b1303",
+    "wof:geomhash":"64da6a6e9c5a2b3866aa1f6c4bd0bbb8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692685,
-    "wof:lastmodified":1566609426,
+    "wof:lastmodified":1695886819,
     "wof:name":"Yatytay",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/268/7/1108692687.geojson
+++ b/data/110/869/268/7/1108692687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009793,
-    "geom:area_square_m":107606625.000407,
+    "geom:area_square_m":107606625.00041,
     "geom:bbox":"-56.0465224397,-27.3488056183,-55.9015625858,-27.2130659679",
     "geom:latitude":-27.29834,
     "geom:longitude":-55.979977,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.SJ",
         "wd:id":"Q1984960"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325660,
-    "wof:geomhash":"18efc2d7053770696ebfd4a0034855c4",
+    "wof:geomhash":"f9f5d51b508dc43518fe8c15f0fb7dda",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692687,
-    "wof:lastmodified":1566609423,
+    "wof:lastmodified":1695886819,
     "wof:name":"San Juan Del Parana",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/268/9/1108692689.geojson
+++ b/data/110/869/268/9/1108692689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076146,
-    "geom:area_square_m":840180585.056279,
+    "geom:area_square_m":840180585.055472,
     "geom:bbox":"-55.7511305003,-26.9875999698,-55.2717309787,-26.6591607821",
     "geom:latitude":-26.833412,
     "geom:longitude":-55.514739,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.IT.PI",
         "wd:id":"Q547894"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325661,
-    "wof:geomhash":"00317c2c5600e32e533a4c8cb28eb1ea",
+    "wof:geomhash":"98733ee4c7211ba33d4d50a5077302b3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692689,
-    "wof:lastmodified":1566609422,
+    "wof:lastmodified":1695886818,
     "wof:name":"Pirapo",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/269/1/1108692691.geojson
+++ b/data/110/869/269/1/1108692691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042891,
-    "geom:area_square_m":474374018.250813,
+    "geom:area_square_m":474374018.250559,
     "geom:bbox":"-55.6559551993,-26.7206003183,-55.3895914864,-26.3556025819",
     "geom:latitude":-26.56135,
     "geom:longitude":-55.545264,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.IP",
         "wd:id":"Q1675227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325662,
-    "wof:geomhash":"90650b7839e11090eeb5c2420dfa783c",
+    "wof:geomhash":"68ac81d678d53afe0bd2abb499bfdc78",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692691,
-    "wof:lastmodified":1566609455,
+    "wof:lastmodified":1695886826,
     "wof:name":"Itapua Poty",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/269/5/1108692695.geojson
+++ b/data/110/869/269/5/1108692695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005833,
-    "geom:area_square_m":64271417.318174,
+    "geom:area_square_m":64271417.3182,
     "geom:bbox":"-56.8937154516,-27.0526427412,-56.7733728494,-26.9373997841",
     "geom:latitude":-26.995449,
     "geom:longitude":-56.829387,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.MI.SP",
         "wd:id":"Q1749429"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325665,
-    "wof:geomhash":"10d5c82ffdb54b3fd5907186c41adae0",
+    "wof:geomhash":"c02bc237f41b54d09306e5c87a66cc7f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692695,
-    "wof:lastmodified":1566609456,
+    "wof:lastmodified":1695886826,
     "wof:name":"San Patricio",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/110/869/269/7/1108692697.geojson
+++ b/data/110/869/269/7/1108692697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033693,
-    "geom:area_square_m":372073979.312927,
+    "geom:area_square_m":372073830.473449,
     "geom:bbox":"-57.001517,-26.848557,-56.763355,-26.60365",
     "geom:latitude":-26.739268,
     "geom:longitude":-56.88897,
@@ -109,9 +109,10 @@
         "hasc:id":"PY.MI.SM",
         "wd:id":"Q1749350"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325666,
-    "wof:geomhash":"6d930a6ab6e0b10d1788653810ede7fb",
+    "wof:geomhash":"abc32c6dcd71caf87d75dbc01faf15f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108692697,
-    "wof:lastmodified":1690857002,
+    "wof:lastmodified":1695886495,
     "wof:name":"Santa Maria",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/110/869/269/9/1108692699.geojson
+++ b/data/110/869/269/9/1108692699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076117,
-    "geom:area_square_m":839575174.795769,
+    "geom:area_square_m":839575056.786123,
     "geom:bbox":"-56.990684,-27.174257,-56.635073,-26.622067",
     "geom:latitude":-26.871364,
     "geom:longitude":-56.794258,
@@ -109,9 +109,10 @@
         "hasc:id":"PY.MI.SR",
         "wd:id":"Q2411012"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325667,
-    "wof:geomhash":"619df178e01dd4aea58f298c88595f58",
+    "wof:geomhash":"482bfc689c4bb08223fa122d4446db13",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108692699,
-    "wof:lastmodified":1636503103,
+    "wof:lastmodified":1695886097,
     "wof:name":"Santa Rosa",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/110/869/270/1/1108692701.geojson
+++ b/data/110/869/270/1/1108692701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0779,
-    "geom:area_square_m":857271839.380537,
+    "geom:area_square_m":857271495.070622,
     "geom:bbox":"-56.984021,-27.281404,-56.625861,-26.924488",
     "geom:latitude":-27.129828,
     "geom:longitude":-56.783755,
@@ -146,9 +146,10 @@
         "hasc:id":"PY.MI.SA",
         "wd:id":"Q2410850"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325668,
-    "wof:geomhash":"2d4c7ff4c6f9dba595b98fe6e7c4f9b9",
+    "wof:geomhash":"427ed650381e4b84aba3784d69306982",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108692701,
-    "wof:lastmodified":1642551789,
+    "wof:lastmodified":1695886521,
     "wof:name":"Santiago",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/110/869/270/3/1108692703.geojson
+++ b/data/110/869/270/3/1108692703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058542,
-    "geom:area_square_m":643513905.13667,
+    "geom:area_square_m":643513311.223189,
     "geom:bbox":"-57.325792,-27.394798,-56.961817,-27.113239",
     "geom:latitude":-27.256282,
     "geom:longitude":-57.143038,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.PG.YC",
         "wd:id":"Q1749675"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325670,
-    "wof:geomhash":"e94073d80cc5a74198b8d1d070095e40",
+    "wof:geomhash":"0fd308f65f2e73071268de4c5dbc0ba8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692703,
-    "wof:lastmodified":1690857003,
+    "wof:lastmodified":1695886826,
     "wof:name":"Yabebyry",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/110/869/270/5/1108692705.geojson
+++ b/data/110/869/270/5/1108692705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028986,
-    "geom:area_square_m":322445174.248246,
+    "geom:area_square_m":322445354.166442,
     "geom:bbox":"-57.207308,-25.977861,-56.915168,-25.790901",
     "geom:latitude":-25.88932,
     "geom:longitude":-57.076594,
@@ -100,9 +100,10 @@
         "hasc:id":"PY.PG.AC",
         "wd:id":"Q926511"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325672,
-    "wof:geomhash":"4aa9e2d7ca1c0710f738bcf6ee4923f7",
+    "wof:geomhash":"ca6a8f76d774417a35e1f27758f591a9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108692705,
-    "wof:lastmodified":1690857004,
+    "wof:lastmodified":1695886826,
     "wof:name":"Acahay",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/270/7/1108692707.geojson
+++ b/data/110/869/270/7/1108692707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.224771,
-    "geom:area_square_m":2490828608.335052,
+    "geom:area_square_m":2490828044.405487,
     "geom:bbox":"-57.749377,-26.619597,-57.075562,-26.072443",
     "geom:latitude":-26.337452,
     "geom:longitude":-57.384496,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.PG.CP",
         "wd:id":"Q2410335"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325673,
-    "wof:geomhash":"2638d4604775816a57aaa54fb0c42c69",
+    "wof:geomhash":"ebfedcc101eb23f9bcc03534dd3113eb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692707,
-    "wof:lastmodified":1690857003,
+    "wof:lastmodified":1695886826,
     "wof:name":"Caapucu",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/270/9/1108692709.geojson
+++ b/data/110/869/270/9/1108692709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022425,
-    "geom:area_square_m":249732189.816397,
+    "geom:area_square_m":249732191.424073,
     "geom:bbox":"-56.997716,-25.888774,-56.758256,-25.623774",
     "geom:latitude":-25.760048,
     "geom:longitude":-56.886128,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.PG.GC",
         "wd:id":"Q1750497"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325675,
-    "wof:geomhash":"7fae22228ef22dd381014d49e35fbc60",
+    "wof:geomhash":"74640e0dceca7d916c110f5c1c7dcd5b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692709,
-    "wof:lastmodified":1690857003,
+    "wof:lastmodified":1695886826,
     "wof:name":"General Bernardino Caballero",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/271/3/1108692713.geojson
+++ b/data/110/869/271/3/1108692713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018231,
-    "geom:area_square_m":203183579.528274,
+    "geom:area_square_m":203183820.724936,
     "geom:bbox":"-57.111465,-25.785422,-56.905302,-25.56175",
     "geom:latitude":-25.668671,
     "geom:longitude":-57.025752,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.PG.ES",
         "wd:id":"Q1750369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325677,
-    "wof:geomhash":"92d4ea21e2e87cf17d67db4eb7153445",
+    "wof:geomhash":"ead27d6eebd059cb06350e0a5d664ab8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692713,
-    "wof:lastmodified":1690857014,
+    "wof:lastmodified":1695886836,
     "wof:name":"Escobar",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/271/5/1108692715.geojson
+++ b/data/110/869/271/5/1108692715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00892,
-    "geom:area_square_m":99212959.57525,
+    "geom:area_square_m":99213157.774833,
     "geom:bbox":"-56.901329,-25.948277,-56.733133,-25.856199",
     "geom:latitude":-25.902249,
     "geom:longitude":-56.823124,
@@ -103,9 +103,10 @@
         "hasc:id":"PY.PG.LC",
         "wd:id":"Q376227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325678,
-    "wof:geomhash":"fdd762dc09b73a887535ff26f56016a6",
+    "wof:geomhash":"0effdcbe365abce3a6ddcd6573921927",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692715,
-    "wof:lastmodified":1690857014,
+    "wof:lastmodified":1695886836,
     "wof:name":"La Colmena",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/271/7/1108692717.geojson
+++ b/data/110/869/271/7/1108692717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081599,
-    "geom:area_square_m":904643217.802505,
+    "geom:area_square_m":904643267.671684,
     "geom:bbox":"-57.009962,-26.541554,-56.628794,-25.972646",
     "geom:latitude":-26.287107,
     "geom:longitude":-56.810989,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.PG.MB",
         "wd:id":"Q2410379"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325679,
-    "wof:geomhash":"967ac28b81e35cef10b8cb128e3ef45b",
+    "wof:geomhash":"cdd02ba7da9a80d5b159023fc73011e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692717,
-    "wof:lastmodified":1690857014,
+    "wof:lastmodified":1695886835,
     "wof:name":"Mbuyapey",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/271/9/1108692719.geojson
+++ b/data/110/869/271/9/1108692719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016513,
-    "geom:area_square_m":184332035.510602,
+    "geom:area_square_m":184331897.869269,
     "geom:bbox":"-57.31946,-25.551105,-57.125809,-25.401783",
     "geom:latitude":-25.477165,
     "geom:longitude":-57.214456,
@@ -103,9 +103,10 @@
         "hasc:id":"PY.PG.PI",
         "wd:id":"Q1750484"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325681,
-    "wof:geomhash":"5ed62712d9b9920f40f3ca9e3de05122",
+    "wof:geomhash":"c88cf2c33c65fc8b8047fc2936d37f53",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692719,
-    "wof:lastmodified":1690857014,
+    "wof:lastmodified":1695886836,
     "wof:name":"Pirayu",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/272/1/1108692721.geojson
+++ b/data/110/869/272/1/1108692721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05957,
-    "geom:area_square_m":661968581.244154,
+    "geom:area_square_m":661968825.142815,
     "geom:bbox":"-57.499619,-26.128672,-57.105405,-25.904643",
     "geom:latitude":-26.013153,
     "geom:longitude":-57.314661,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.PG.QI",
         "wd:id":"Q2410952"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325682,
-    "wof:geomhash":"e2224b19e48db3818bc97162339c82c2",
+    "wof:geomhash":"d0ae4e22a57af40f92b2538bc1847289",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692721,
-    "wof:lastmodified":1690856990,
+    "wof:lastmodified":1695886816,
     "wof:name":"Quiindy",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/272/3/1108692723.geojson
+++ b/data/110/869/272/3/1108692723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052643,
-    "geom:area_square_m":583793777.973173,
+    "geom:area_square_m":583793777.973826,
     "geom:bbox":"-57.1472617207,-26.4179859075,-56.8568208342,-26.1128559691",
     "geom:latitude":-26.252735,
     "geom:longitude":-57.010441,
@@ -100,9 +100,10 @@
         "hasc:id":"PY.PG.QQ",
         "wd:id":"Q2639204"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325683,
-    "wof:geomhash":"d44b881515ae2fd7782c50a58b5b40b4",
+    "wof:geomhash":"e9e39f30f7439860bab7957e4fbcf6d9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108692723,
-    "wof:lastmodified":1566609411,
+    "wof:lastmodified":1695886816,
     "wof:name":"Quyquyho",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/272/5/1108692725.geojson
+++ b/data/110/869/272/5/1108692725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021488,
-    "geom:area_square_m":239070513.890192,
+    "geom:area_square_m":239070513.890206,
     "geom:bbox":"-57.4467985487,-25.9495279112,-57.1633537201,-25.8069206566",
     "geom:latitude":-25.875588,
     "geom:longitude":-57.297507,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.PG.SG",
         "wd:id":"Q1750382"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325684,
-    "wof:geomhash":"6e96aad462de306ed9961bfb982673ee",
+    "wof:geomhash":"b673ba1ac5fcbf0851b6b153c106ba66",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692725,
-    "wof:lastmodified":1566609412,
+    "wof:lastmodified":1695886816,
     "wof:name":"San Roque Gonzalez",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/272/7/1108692727.geojson
+++ b/data/110/869/272/7/1108692727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012211,
-    "geom:area_square_m":135810038.195925,
+    "geom:area_square_m":135810071.229573,
     "geom:bbox":"-56.752771,-25.979505,-56.607556,-25.847711",
     "geom:latitude":-25.918018,
     "geom:longitude":-56.674784,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.PG.TE",
         "wd:id":"Q2410898"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325686,
-    "wof:geomhash":"ef51a571a26f9272a719d28e07ee8ffc",
+    "wof:geomhash":"8468bc8bcf42946449d229d67c454584",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692727,
-    "wof:lastmodified":1690856990,
+    "wof:lastmodified":1695886816,
     "wof:name":"Tebicuary-mi",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/273/1/1108692731.geojson
+++ b/data/110/869/273/1/1108692731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022733,
-    "geom:area_square_m":253509481.187836,
+    "geom:area_square_m":253509501.178829,
     "geom:bbox":"-57.388168,-25.677206,-57.17825,-25.497725",
     "geom:latitude":-25.598694,
     "geom:longitude":-57.274764,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.PG.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325687,
-    "wof:geomhash":"993d009918fe092f8a80a7ac4741904a",
+    "wof:geomhash":"839f5f008b34c9caa48954bd30869bd4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692731,
-    "wof:lastmodified":1642551768,
+    "wof:lastmodified":1695886514,
     "wof:name":"Yaguaron",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/273/3/1108692733.geojson
+++ b/data/110/869/273/3/1108692733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074949,
-    "geom:area_square_m":832690241.614067,
+    "geom:area_square_m":832690113.345177,
     "geom:bbox":"-57.142413,-26.219833,-56.73702,-25.906893",
     "geom:latitude":-26.038392,
     "geom:longitude":-56.937655,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.PG.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325688,
-    "wof:geomhash":"8abc083d951d34973292c3a86bd7f202",
+    "wof:geomhash":"3cb9ceee4b9c96a9ea37903c70b680cc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692733,
-    "wof:lastmodified":1627522524,
+    "wof:lastmodified":1695886171,
     "wof:name":"Yvycui",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/273/5/1108692735.geojson
+++ b/data/110/869/273/5/1108692735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03533,
-    "geom:area_square_m":393378419.65445,
+    "geom:area_square_m":393378501.852679,
     "geom:bbox":"-56.917821,-25.914921,-56.666513,-25.646366",
     "geom:latitude":-25.78094,
     "geom:longitude":-56.767048,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.PG.YT",
         "wd:id":"Q2410921"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325690,
-    "wof:geomhash":"c67f106e245b3f6c3fbf3415f7edccda",
+    "wof:geomhash":"5e0d4b514d00ac521eb14245369a45a7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692735,
-    "wof:lastmodified":1690856984,
+    "wof:lastmodified":1695886813,
     "wof:name":"Yvytimi",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/110/869/273/7/1108692737.geojson
+++ b/data/110/869/273/7/1108692737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030577,
-    "geom:area_square_m":340229493.688508,
+    "geom:area_square_m":340229493.688521,
     "geom:bbox":"-54.8131475216,-25.9853644117,-54.5871246556,-25.7609180358",
     "geom:latitude":-25.858222,
     "geom:longitude":-54.690235,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.AA.DI",
         "wd:id":"Q1987175"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325692,
-    "wof:geomhash":"f93bf216698a6b87ca42a034d244c694",
+    "wof:geomhash":"9f5c30e969ed36874d696b312a9a673e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692737,
-    "wof:lastmodified":1566609395,
+    "wof:lastmodified":1695886813,
     "wof:name":"Domingo Martinez De Irala",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/110/869/273/9/1108692739.geojson
+++ b/data/110/869/273/9/1108692739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096984,
-    "geom:area_square_m":1092536513.142436,
+    "geom:area_square_m":1092536590.489305,
     "geom:bbox":"-55.373468,-24.551203,-54.921494,-24.112129",
     "geom:latitude":-24.350899,
     "geom:longitude":-55.116196,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CY.VC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325693,
-    "wof:geomhash":"3cba0e4bce8d2b5a68e5e106683f1119",
+    "wof:geomhash":"685b88b692940ca5b1bfa1ff0b180ac0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692739,
-    "wof:lastmodified":1627522525,
+    "wof:lastmodified":1695886173,
     "wof:name":"Yvyrarobana",
     "wof:parent_id":85676719,
     "wof:placetype":"county",

--- a/data/110/869/274/1/1108692741.geojson
+++ b/data/110/869/274/1/1108692741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.331298,
-    "geom:area_square_m":15179805462.274906,
+    "geom:area_square_m":15179806086.733917,
     "geom:bbox":"-59.285183,-23.36074,-57.667017,-22.131614",
     "geom:latitude":-22.758809,
     "geom:longitude":-58.490172,
@@ -178,9 +178,10 @@
         "hasc:id":"PY.PH.PP",
         "wd:id":"Q3925400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325695,
-    "wof:geomhash":"f29a84e54d459d1d10b947e9dba1af87",
+    "wof:geomhash":"9a8e06b268bd62e42c89ed4ee919c3d5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":1108692741,
-    "wof:lastmodified":1636503099,
+    "wof:lastmodified":1695886090,
     "wof:name":"Puerto Pinasco",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/110/869/274/3/1108692743.geojson
+++ b/data/110/869/274/3/1108692743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042226,
-    "geom:area_square_m":464975768.936157,
+    "geom:area_square_m":464975768.936285,
     "geom:bbox":"-56.6470298771,-27.2331943238,-56.4367524995,-26.8881594091",
     "geom:latitude":-27.059518,
     "geom:longitude":-56.552196,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.IT.GD",
         "wd:id":"Q1985386"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325697,
-    "wof:geomhash":"a214eba684290679f481e9fea18daa71",
+    "wof:geomhash":"dee8fcd9028c1933da27ec28d1ba979e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692743,
-    "wof:lastmodified":1566609394,
+    "wof:lastmodified":1695886813,
     "wof:name":"General Delgado",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/274/5/1108692745.geojson
+++ b/data/110/869/274/5/1108692745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187173,
-    "geom:area_square_m":2126371518.363537,
+    "geom:area_square_m":2126371193.889812,
     "geom:bbox":"-57.206658,-23.483129,-56.547022,-22.993563",
     "geom:latitude":-23.256506,
     "geom:longitude":-56.837998,
@@ -145,9 +145,10 @@
         "hasc:id":"PY.CN.HO",
         "wd:id":"Q2639236"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325701,
-    "wof:geomhash":"8833d656e9e8fe42ad6e74e7df2ac750",
+    "wof:geomhash":"0cef632df9eb0b4196793f0fe021d7f5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108692745,
-    "wof:lastmodified":1636503100,
+    "wof:lastmodified":1695886092,
     "wof:name":"Horqueta",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/274/9/1108692749.geojson
+++ b/data/110/869/274/9/1108692749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071988,
-    "geom:area_square_m":818234128.150721,
+    "geom:area_square_m":818234383.534013,
     "geom:bbox":"-57.378252,-23.355072,-56.894144,-23.051185",
     "geom:latitude":-23.18896,
     "geom:longitude":-57.151191,
@@ -109,9 +109,10 @@
         "hasc:id":"PY.CN.LO",
         "wd:id":"Q3837130"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325702,
-    "wof:geomhash":"a2c479dbf4f1472d63e4425fa7403171",
+    "wof:geomhash":"a1828534912b9265d02ef141787ee2da",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108692749,
-    "wof:lastmodified":1642551774,
+    "wof:lastmodified":1695886517,
     "wof:name":"Loreto",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/275/1/1108692751.geojson
+++ b/data/110/869/275/1/1108692751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169192,
-    "geom:area_square_m":1934330983.927837,
+    "geom:area_square_m":1934331280.095455,
     "geom:bbox":"-57.626105,-22.7015,-56.98375,-22.168184",
     "geom:latitude":-22.392954,
     "geom:longitude":-57.297788,
@@ -121,9 +121,10 @@
         "hasc:id":"PY.CN.SC",
         "wd:id":"Q6321670"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325703,
-    "wof:geomhash":"1122bd8b5346427efb3448d3b5af9264",
+    "wof:geomhash":"ceb18a4f4cfc1f2894ccd0dd4e9afb12",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108692751,
-    "wof:lastmodified":1636503102,
+    "wof:lastmodified":1695886095,
     "wof:name":"San Carlos",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/275/3/1108692753.geojson
+++ b/data/110/869/275/3/1108692753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104103,
-    "geom:area_square_m":1191426115.966845,
+    "geom:area_square_m":1191426115.967407,
     "geom:bbox":"-57.9937844334,-22.4161789052,-57.4992309232,-22.0790876114",
     "geom:latitude":-22.247185,
     "geom:longitude":-57.735041,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CN.SL",
         "wd:id":"Q1990310"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325705,
-    "wof:geomhash":"7ac72861a955835dec6e6c2b7a816fee",
+    "wof:geomhash":"434f1a8cdfcf1425926a9030f6c12e45",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692753,
-    "wof:lastmodified":1566609414,
+    "wof:lastmodified":1695886816,
     "wof:name":"San Lazaro",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/275/5/1108692755.geojson
+++ b/data/110/869/275/5/1108692755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.193058,
-    "geom:area_square_m":2197484684.917625,
+    "geom:area_square_m":2197484905.062201,
     "geom:bbox":"-56.722361,-23.273943,-56.125778,-22.686865",
     "geom:latitude":-22.99614,
     "geom:longitude":-56.381428,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CN.YY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325706,
-    "wof:geomhash":"c1e9ddbe4f55b52fb8fc0063e6751488",
+    "wof:geomhash":"3f372762f7e4a09210edc83cf1189fcd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692755,
-    "wof:lastmodified":1627522524,
+    "wof:lastmodified":1695886172,
     "wof:name":"Yvy Ya\u00b4u",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/275/7/1108692757.geojson
+++ b/data/110/869/275/7/1108692757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063689,
-    "geom:area_square_m":723176269.541794,
+    "geom:area_square_m":723176399.85896,
     "geom:bbox":"-56.726394,-23.458558,-56.281779,-23.11619",
     "geom:latitude":-23.32344,
     "geom:longitude":-56.501137,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CN.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325707,
-    "wof:geomhash":"4d8e0a72d8a2b472cff3f60c7389f6cd",
+    "wof:geomhash":"6b88378d70ec54f37f55027bbac6b255",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692757,
-    "wof:lastmodified":1627522520,
+    "wof:lastmodified":1695886164,
     "wof:name":"Azotey",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/275/9/1108692759.geojson
+++ b/data/110/869/275/9/1108692759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198056,
-    "geom:area_square_m":2262031987.359194,
+    "geom:area_square_m":2262032451.468139,
     "geom:bbox":"-57.277484,-22.786026,-56.609426,-22.237921",
     "geom:latitude":-22.532576,
     "geom:longitude":-56.94168,
@@ -48,10 +48,13 @@
         85676665
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"0109"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"PY",
     "wof:created":1474325708,
-    "wof:geomhash":"9e9f7bef142dbe37c3404f1317fb38c6",
+    "wof:geomhash":"6a4033a0176f6e38540271734c06e0d4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":1108692759,
-    "wof:lastmodified":1627522522,
+    "wof:lastmodified":1695886169,
     "wof:name":"Sgto. Jose Felix Lopez",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/110/869/276/1/1108692761.geojson
+++ b/data/110/869/276/1/1108692761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.290216,
-    "geom:area_square_m":3284094131.396558,
+    "geom:area_square_m":3284094805.256852,
     "geom:bbox":"-57.473517,-24.157767,-56.697388,-23.442021",
     "geom:latitude":-23.772186,
     "geom:longitude":-57.059513,
@@ -127,9 +127,10 @@
         "hasc:id":"PY.SP.SY",
         "wd:id":"Q135993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325709,
-    "wof:geomhash":"9396f2925ad873dbba0fcc7ee68ef710",
+    "wof:geomhash":"c3536da8419c06bfef85abaeacebdfb7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108692761,
-    "wof:lastmodified":1690857011,
+    "wof:lastmodified":1695886833,
     "wof:name":"San Pedro Del Ykuamandiyu",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/276/3/1108692763.geojson
+++ b/data/110/869/276/3/1108692763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042498,
-    "geom:area_square_m":479729443.160023,
+    "geom:area_square_m":479729443.160062,
     "geom:bbox":"-57.2798455183,-24.2666589321,-57.0711243294,-23.9048832218",
     "geom:latitude":-24.090757,
     "geom:longitude":-57.169171,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.SP.AN",
         "wd:id":"Q2397118"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325710,
-    "wof:geomhash":"d19b596cbfa02a85c32c5e951759eb79",
+    "wof:geomhash":"c8b6de356209f3c053ab40bbe7d2f622",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692763,
-    "wof:lastmodified":1566609486,
+    "wof:lastmodified":1695886833,
     "wof:name":"Antequera",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/276/7/1108692767.geojson
+++ b/data/110/869/276/7/1108692767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062466,
-    "geom:area_square_m":704613241.433938,
+    "geom:area_square_m":704613241.434165,
     "geom:bbox":"-56.8125734956,-24.3559666456,-56.4840346773,-24.0342085819",
     "geom:latitude":-24.184314,
     "geom:longitude":-56.632884,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.SP.CH",
         "wd:id":"Q2639249"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325712,
-    "wof:geomhash":"f27b20b0383ba8452fe871f549e92d6d",
+    "wof:geomhash":"287aac8202cbe20e1cbf82fca38f4b95",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692767,
-    "wof:lastmodified":1566609484,
+    "wof:lastmodified":1695886833,
     "wof:name":"Chore",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/276/9/1108692769.geojson
+++ b/data/110/869/276/9/1108692769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072221,
-    "geom:area_square_m":813370056.343616,
+    "geom:area_square_m":813370056.343526,
     "geom:bbox":"-57.0079184434,-24.53592591,-56.601087003,-24.1946754607",
     "geom:latitude":-24.383363,
     "geom:longitude":-56.793329,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.SP.GA",
         "wd:id":"Q1989449"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325713,
-    "wof:geomhash":"988c816c5d14661a9d4380c8eb605530",
+    "wof:geomhash":"c5e5a411a6bbc793c7e3efd7195bac2a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692769,
-    "wof:lastmodified":1566609484,
+    "wof:lastmodified":1695886833,
     "wof:name":"General Elizardo Aquino",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/277/1/1108692771.geojson
+++ b/data/110/869/277/1/1108692771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068713,
-    "geom:area_square_m":772643483.056552,
+    "geom:area_square_m":772643008.844967,
     "geom:bbox":"-57.033474,-24.736438,-56.579511,-24.437158",
     "geom:latitude":-24.582386,
     "geom:longitude":-56.819594,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.SP.IR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325714,
-    "wof:geomhash":"7b45f65fb2c3477e22678b6153ef831e",
+    "wof:geomhash":"0f43f5e720583098eff0c7c5f29ec6c4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692771,
-    "wof:lastmodified":1627522522,
+    "wof:lastmodified":1695886169,
     "wof:name":"Itacurubi Del Rosario",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/277/3/1108692773.geojson
+++ b/data/110/869/277/3/1108692773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056981,
-    "geom:area_square_m":643778956.720018,
+    "geom:area_square_m":643779082.071003,
     "geom:bbox":"-56.818933,-24.080125,-56.368227,-23.864542",
     "geom:latitude":-23.978333,
     "geom:longitude":-56.569352,
@@ -103,9 +103,10 @@
         "hasc:id":"PY.SP.LI",
         "wd:id":"Q590046"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325715,
-    "wof:geomhash":"8d58839abf202647492541c85ac0d04e",
+    "wof:geomhash":"596df17ff1b3bf600c7e39814293ec34",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108692773,
-    "wof:lastmodified":1636503105,
+    "wof:lastmodified":1695886099,
     "wof:name":"Lima",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/277/5/1108692775.geojson
+++ b/data/110/869/277/5/1108692775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057649,
-    "geom:area_square_m":652792875.626675,
+    "geom:area_square_m":652793003.893761,
     "geom:bbox":"-56.74662,-23.936317,-56.110924,-23.492972",
     "geom:latitude":-23.685579,
     "geom:longitude":-56.431551,
@@ -112,9 +112,10 @@
         "hasc:id":"PY.SP.NG",
         "wd:id":"Q928198"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325716,
-    "wof:geomhash":"a79843bd7b9efdebf56fa6da3e1b42ed",
+    "wof:geomhash":"779aafadef331ad89d3126c7519389fe",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108692775,
-    "wof:lastmodified":1690857007,
+    "wof:lastmodified":1695886830,
     "wof:name":"Nueva Germania",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/277/7/1108692777.geojson
+++ b/data/110/869/277/7/1108692777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.504059,
-    "geom:area_square_m":17283675676.968479,
+    "geom:area_square_m":17283675676.968342,
     "geom:bbox":"-59.9530677622,-22.3992232634,-57.8171488333,-21.0449786427",
     "geom:latitude":-21.666912,
     "geom:longitude":-58.979862,
@@ -175,9 +175,10 @@
         "hasc:id":"PY.AG.LV",
         "wd:id":"Q2636535"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325719,
-    "wof:geomhash":"ece4b20098ab3f461578c97f969cc45b",
+    "wof:geomhash":"627b065c82c95008e29185451be9f919",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108692777,
-    "wof:lastmodified":1566609468,
+    "wof:lastmodified":1695886829,
     "wof:name":"Puerto Casado",
     "wof:parent_id":85676655,
     "wof:placetype":"county",

--- a/data/110/869/277/9/1108692779.geojson
+++ b/data/110/869/277/9/1108692779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.14989,
-    "geom:area_square_m":36624739612.898331,
+    "geom:area_square_m":36624737800.945366,
     "geom:bbox":"-61.9224,-20.632887,-57.996698,-19.2896",
     "geom:latitude":-19.893155,
     "geom:longitude":-59.965117,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.AG.ML",
         "wd:id":"Q3321191"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325721,
-    "wof:geomhash":"530ad8a9ae3709d08d003c8818ed4f1f",
+    "wof:geomhash":"d80a998c1555f71fac976c150e74a3e9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692779,
-    "wof:lastmodified":1690857006,
+    "wof:lastmodified":1695886830,
     "wof:name":"Bahia Negra",
     "wof:parent_id":85676655,
     "wof:placetype":"county",

--- a/data/110/869/278/1/1108692781.geojson
+++ b/data/110/869/278/1/1108692781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.458894,
-    "geom:area_square_m":5273973048.696883,
+    "geom:area_square_m":5273972219.678908,
     "geom:bbox":"-58.776171,-22.043623,-57.852181,-21.278146",
     "geom:latitude":-21.649995,
     "geom:longitude":-58.280775,
@@ -60,9 +60,10 @@
     "wof:concordances":{
         "hasc:id":"PY.AG.LV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325722,
-    "wof:geomhash":"1bc0e215e5ecaa259a8ba016b5bd8911",
+    "wof:geomhash":"8a6662a26af6e867f40d4a6ccbd3e95f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -72,7 +73,7 @@
         }
     ],
     "wof:id":1108692781,
-    "wof:lastmodified":1642551760,
+    "wof:lastmodified":1695886511,
     "wof:name":"Carmelo Peralta",
     "wof:parent_id":85676655,
     "wof:placetype":"county",

--- a/data/110/869/278/5/1108692785.geojson
+++ b/data/110/869/278/5/1108692785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120872,
-    "geom:area_square_m":1336293850.394632,
+    "geom:area_square_m":1336293850.394428,
     "geom:bbox":"-58.171297117,-26.8634133808,-57.5832568507,-26.3812235221",
     "geom:latitude":-26.610163,
     "geom:longitude":-57.857719,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.NE.SN",
         "wd:id":"Q2410909"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325723,
-    "wof:geomhash":"ef69db9daa941f30dc24a4333f22531e",
+    "wof:geomhash":"361a3be44a3a9375045ef21abb505ede",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692785,
-    "wof:lastmodified":1566609478,
+    "wof:lastmodified":1695886832,
     "wof:name":"San Juan Bautista De \u00d1eembucu",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/278/7/1108692787.geojson
+++ b/data/110/869/278/7/1108692787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163934,
-    "geom:area_square_m":1807679127.352156,
+    "geom:area_square_m":1807679127.35201,
     "geom:bbox":"-58.2610817886,-27.1795469178,-57.1820936049,-26.5957063761",
     "geom:latitude":-26.90378,
     "geom:longitude":-57.749701,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.NE.TA",
         "wd:id":"Q1750366"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325725,
-    "wof:geomhash":"04a135ac8ee1630cb93da40636b1fcea",
+    "wof:geomhash":"ab9943cd6117c2b0c5427cf39eee0544",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692787,
-    "wof:lastmodified":1566609477,
+    "wof:lastmodified":1695886831,
     "wof:name":"Tacuaras",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/278/9/1108692789.geojson
+++ b/data/110/869/278/9/1108692789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139233,
-    "geom:area_square_m":1542801252.926559,
+    "geom:area_square_m":1542800750.698323,
     "geom:bbox":"-58.231059,-26.604783,-57.619689,-26.144625",
     "geom:latitude":-26.347354,
     "geom:longitude":-57.960241,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"PY.NE.VF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325726,
-    "wof:geomhash":"7c553349bedd4cceb770aff920842ebc",
+    "wof:geomhash":"6722fec1893524667848e861ef2d367e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108692789,
-    "wof:lastmodified":1642551760,
+    "wof:lastmodified":1695886512,
     "wof:name":"Villa Franca",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/279/1/1108692791.geojson
+++ b/data/110/869/279/1/1108692791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142994,
-    "geom:area_square_m":1588602686.990897,
+    "geom:area_square_m":1588602686.991356,
     "geom:bbox":"-58.0942089753,-26.2382420526,-57.4681359439,-25.7671761833",
     "geom:latitude":-26.044147,
     "geom:longitude":-57.727556,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.NE.VO",
         "wd:id":"Q1750358"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325727,
-    "wof:geomhash":"e08d478d7d7ed502011f500663d3f252",
+    "wof:geomhash":"502d2b99c6b46931bbd08f4202d5d0b1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692791,
-    "wof:lastmodified":1566609473,
+    "wof:lastmodified":1695886831,
     "wof:name":"Villa Oliva",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/279/3/1108692793.geojson
+++ b/data/110/869/279/3/1108692793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001654,
-    "geom:area_square_m":18476137.338332,
+    "geom:area_square_m":18476162.186636,
     "geom:bbox":"-57.613791,-25.40176,-57.566761,-25.339359",
     "geom:latitude":-25.373756,
     "geom:longitude":-57.587438,
@@ -190,9 +190,10 @@
         "hasc:id":"PY.CE.VE",
         "wd:id":"Q952896"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325728,
-    "wof:geomhash":"a2de35f88870e866ae4b6796f203b700",
+    "wof:geomhash":"61ff93eac262faf8099676cfae17ecdd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1108692793,
-    "wof:lastmodified":1690857008,
+    "wof:lastmodified":1695886831,
     "wof:name":"Villa Elisa",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/279/5/1108692795.geojson
+++ b/data/110/869/279/5/1108692795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004709,
-    "geom:area_square_m":52573687.377963,
+    "geom:area_square_m":52573630.363386,
     "geom:bbox":"-57.567442,-25.497673,-57.459345,-25.422747",
     "geom:latitude":-25.460402,
     "geom:longitude":-57.509294,
@@ -181,9 +181,10 @@
         "hasc:id":"PY.CE.YN",
         "wd:id":"Q2717436"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325730,
-    "wof:geomhash":"8f0dbf9cca96be31cd4ceb29d6681d14",
+    "wof:geomhash":"a82bd9cf406fd8431f3faa10551955d0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -193,7 +194,7 @@
         }
     ],
     "wof:id":1108692795,
-    "wof:lastmodified":1690857008,
+    "wof:lastmodified":1695886831,
     "wof:name":"Ypane",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/279/9/1108692799.geojson
+++ b/data/110/869/279/9/1108692799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002881,
-    "geom:area_square_m":32166935.154479,
+    "geom:area_square_m":32166996.457692,
     "geom:bbox":"-57.471779,-25.460238,-57.398687,-25.396183",
     "geom:latitude":-25.432685,
     "geom:longitude":-57.433888,
@@ -178,9 +178,10 @@
         "hasc:id":"PY.CE.JS",
         "wd:id":"Q2717412"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325732,
-    "wof:geomhash":"872229a719cce3073191c85a8dce82a9",
+    "wof:geomhash":"47f3a5a5444e4827ce6142b0b47ddd38",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -190,7 +191,7 @@
         }
     ],
     "wof:id":1108692799,
-    "wof:lastmodified":1690857007,
+    "wof:lastmodified":1695886831,
     "wof:name":"J Augusto Saldivar",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/280/3/1108692803.geojson
+++ b/data/110/869/280/3/1108692803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025959,
-    "geom:area_square_m":285781751.629127,
+    "geom:area_square_m":285781751.629164,
     "geom:bbox":"-58.2824105981,-27.1508050254,-57.9858486388,-27.0168251436",
     "geom:latitude":-27.087964,
     "geom:longitude":-58.124058,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.NE.DE",
         "wd:id":"Q2422822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325734,
-    "wof:geomhash":"785e363e6a5d45d6d8b64c5de58162d6",
+    "wof:geomhash":"92240b4d66d55c9db2f8287ce1e7745a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692803,
-    "wof:lastmodified":1566609390,
+    "wof:lastmodified":1695886813,
     "wof:name":"Desmochados",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/280/5/1108692805.geojson
+++ b/data/110/869/280/5/1108692805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080186,
-    "geom:area_square_m":884024527.919421,
+    "geom:area_square_m":884024661.738038,
     "geom:bbox":"-58.294893,-27.099167,-57.610891,-26.742258",
     "geom:latitude":-26.92643,
     "geom:longitude":-57.99032,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.NE.GC",
         "wd:id":"Q387428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325735,
-    "wof:geomhash":"7d19615346c13233ba4d37c6d07f6db6",
+    "wof:geomhash":"acac9d76c0ab983b6c29533cc1a07d65",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692805,
-    "wof:lastmodified":1690856983,
+    "wof:lastmodified":1695886813,
     "wof:name":"Guazu Cua",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/280/7/1108692807.geojson
+++ b/data/110/869/280/7/1108692807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035742,
-    "geom:area_square_m":393082308.776067,
+    "geom:area_square_m":393082336.45506,
     "geom:bbox":"-58.285707,-27.277199,-57.995984,-27.126428",
     "geom:latitude":-27.200891,
     "geom:longitude":-58.14559,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.NE.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325736,
-    "wof:geomhash":"e30a3d85cb5d3c3538d46981beacee4e",
+    "wof:geomhash":"48a4dbf16c8fed8763033d03469fb7f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692807,
-    "wof:lastmodified":1642551781,
+    "wof:lastmodified":1695886519,
     "wof:name":"Mayor Martinez",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/280/9/1108692809.geojson
+++ b/data/110/869/280/9/1108692809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020929,
-    "geom:area_square_m":230036997.018052,
+    "geom:area_square_m":230036997.018221,
     "geom:bbox":"-55.7458127164,-27.3701522891,-55.5768619802,-27.1420017493",
     "geom:latitude":-27.263434,
     "geom:longitude":-55.653227,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.IT.NA",
         "wd:id":"Q1754733"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325738,
-    "wof:geomhash":"6877c02e8815d9638ada84d268b65289",
+    "wof:geomhash":"08493f81556d74148991b0553cd19302",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692809,
-    "wof:lastmodified":1566609389,
+    "wof:lastmodified":1695886813,
     "wof:name":"Nueva Alborada",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/281/1/1108692811.geojson
+++ b/data/110/869/281/1/1108692811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009989,
-    "geom:area_square_m":110837709.213879,
+    "geom:area_square_m":110837709.213902,
     "geom:bbox":"-58.1593157463,-26.2504097946,-58.0003208514,-26.1256132801",
     "geom:latitude":-26.189921,
     "geom:longitude":-58.070904,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.NE.AL",
         "wd:id":"Q2169955"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325739,
-    "wof:geomhash":"d62ff9e9b6df26a778e06fd8b651a49f",
+    "wof:geomhash":"41207bacb2b65de2354d094b93edf5c0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692811,
-    "wof:lastmodified":1566609416,
+    "wof:lastmodified":1695886817,
     "wof:name":"Alberdi",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/281/3/1108692813.geojson
+++ b/data/110/869/281/3/1108692813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164356,
-    "geom:area_square_m":1843232453.131195,
+    "geom:area_square_m":1843231843.747506,
     "geom:bbox":"-58.502032,-25.270191,-57.643582,-24.689553",
     "geom:latitude":-24.909689,
     "geom:longitude":-58.124103,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.PH.JF",
         "wd:id":"Q2475375"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325743,
-    "wof:geomhash":"75def05dd923dcc18e88f749c15db1f4",
+    "wof:geomhash":"ddb2652a669d3c3daad547916cae9b04",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692813,
-    "wof:lastmodified":1690856991,
+    "wof:lastmodified":1695886817,
     "wof:name":"Jose Falcon",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/110/869/281/5/1108692815.geojson
+++ b/data/110/869/281/5/1108692815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.181314,
-    "geom:area_square_m":13442357598.262493,
+    "geom:area_square_m":13442357946.906149,
     "geom:bbox":"-60.407038,-23.823629,-58.852064,-22.076224",
     "geom:latitude":-23.032365,
     "geom:longitude":-59.614204,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.PH.PC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325745,
-    "wof:geomhash":"e6c2f5f710c3a617b95be65036cfa3d2",
+    "wof:geomhash":"356fc91f6f28bb01e7dbc95fa4b56892",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692815,
-    "wof:lastmodified":1642551746,
+    "wof:lastmodified":1695886507,
     "wof:name":"Tte 1ro Manuel Irala Fernandez",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/110/869/281/7/1108692817.geojson
+++ b/data/110/869/281/7/1108692817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.710682,
-    "geom:area_square_m":8033373718.03025,
+    "geom:area_square_m":8033373067.994634,
     "geom:bbox":"-60.785391,-24.49785,-59.077755,-23.443132",
     "geom:latitude":-23.912686,
     "geom:longitude":-59.743788,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.PH.VH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325746,
-    "wof:geomhash":"2387bc1ed407e7693913ea7871a1ff86",
+    "wof:geomhash":"8479efbb6c21a79042cb1ea3beac5e52",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692817,
-    "wof:lastmodified":1627522523,
+    "wof:lastmodified":1695886171,
     "wof:name":"Tte. Esteban Martinez",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/110/869/282/1/1108692821.geojson
+++ b/data/110/869/282/1/1108692821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.582,
-    "geom:area_square_m":6558277288.863697,
+    "geom:area_square_m":6558277857.376453,
     "geom:bbox":"-59.343049,-24.850966,-58.475293,-23.701562",
     "geom:latitude":-24.312065,
     "geom:longitude":-58.875262,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.PH.VH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325747,
-    "wof:geomhash":"0603659c1dd09d4bf5520c595f33c8c9",
+    "wof:geomhash":"30f0d98165e16ac90455e4884328a27a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692821,
-    "wof:lastmodified":1627522521,
+    "wof:lastmodified":1695886167,
     "wof:name":"General Jose Maria Bruguez",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/110/869/282/3/1108692823.geojson
+++ b/data/110/869/282/3/1108692823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02915,
-    "geom:area_square_m":328923335.306054,
+    "geom:area_square_m":328923340.877258,
     "geom:bbox":"-57.089827,-24.201058,-56.766356,-24.067989",
     "geom:latitude":-24.138094,
     "geom:longitude":-56.919289,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.SP.SP",
         "wd:id":"Q1989466"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325749,
-    "wof:geomhash":"0d5e99ca7703a578b35be90602868c29",
+    "wof:geomhash":"f65ed8c27b6f9441a632c22b1eb4fde6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692823,
-    "wof:lastmodified":1636503106,
+    "wof:lastmodified":1695886100,
     "wof:name":"San Pablo",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/282/5/1108692825.geojson
+++ b/data/110/869/282/5/1108692825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194246,
-    "geom:area_square_m":2201963281.879028,
+    "geom:area_square_m":2201963281.879962,
     "geom:bbox":"-56.9795815415,-23.7977866396,-56.1471861973,-23.3006958468",
     "geom:latitude":-23.542501,
     "geom:longitude":-56.592784,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.SP.TA",
         "wd:id":"Q371991"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325750,
-    "wof:geomhash":"4cee619a2dff64c0dca77ddc3677b7df",
+    "wof:geomhash":"d4bee522ef4819585e0540ec473745d8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692825,
-    "wof:lastmodified":1566609490,
+    "wof:lastmodified":1695886834,
     "wof:name":"Tacuati",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/282/7/1108692827.geojson
+++ b/data/110/869/282/7/1108692827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05344,
-    "geom:area_square_m":599509342.489453,
+    "geom:area_square_m":599509342.489573,
     "geom:bbox":"-56.6874316971,-25.0038861632,-56.3911877355,-24.7071133932",
     "geom:latitude":-24.869902,
     "geom:longitude":-56.530898,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.SP.UN",
         "wd:id":"Q2449203"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325751,
-    "wof:geomhash":"36509871ed331b6d13499759d26839c8",
+    "wof:geomhash":"b7f987b50076c10fffbee11d08ac7984",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692827,
-    "wof:lastmodified":1566609487,
+    "wof:lastmodified":1695886834,
     "wof:name":"Union",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/282/9/1108692829.geojson
+++ b/data/110/869/282/9/1108692829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089078,
-    "geom:area_square_m":1000105701.991661,
+    "geom:area_square_m":1000105701.991626,
     "geom:bbox":"-57.0637538637,-24.9822090591,-56.5388678553,-24.6290182064",
     "geom:latitude":-24.772559,
     "geom:longitude":-56.801263,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.SP.VD",
         "wd:id":"Q2475435"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325753,
-    "wof:geomhash":"ab272fedb66d3bcf84bd5d81d17a784e",
+    "wof:geomhash":"ed0a78caaeff52bb1913bd0c3d832bbd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692829,
-    "wof:lastmodified":1566609486,
+    "wof:lastmodified":1695886833,
     "wof:name":"25 De Diciembre",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/283/1/1108692831.geojson
+++ b/data/110/869/283/1/1108692831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175839,
-    "geom:area_square_m":1977528539.02819,
+    "geom:area_square_m":1977528539.028517,
     "geom:bbox":"-57.300132993,-25.0192518148,-56.8116179011,-24.167661736",
     "geom:latitude":-24.561086,
     "geom:longitude":-57.07704,
@@ -79,9 +79,10 @@
         "hasc:id":"PY.SP.VR",
         "wd:id":"Q4012700"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325754,
-    "wof:geomhash":"88d4738a7d1513d1a48f8a1d818fbc4b",
+    "wof:geomhash":"1b72a6717f1fa26cd48d001d622cb78b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108692831,
-    "wof:lastmodified":1566609466,
+    "wof:lastmodified":1695886829,
     "wof:name":"Villa Del Rosario",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/110/869/283/3/1108692833.geojson
+++ b/data/110/869/283/3/1108692833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041592,
-    "geom:area_square_m":465125083.71929,
+    "geom:area_square_m":465125066.59582,
     "geom:bbox":"-55.564704,-25.362907,-55.219968,-25.134097",
     "geom:latitude":-25.258781,
     "geom:longitude":-55.390494,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CG.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325755,
-    "wof:geomhash":"bd41d0f01821573079c551bc304d4f2d",
+    "wof:geomhash":"df3ba6d3e6ba7e0780db536969a48d5d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692833,
-    "wof:lastmodified":1627522523,
+    "wof:lastmodified":1695886171,
     "wof:name":"Tembiapora",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/283/5/1108692835.geojson
+++ b/data/110/869/283/5/1108692835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053704,
-    "geom:area_square_m":601972658.854651,
+    "geom:area_square_m":601972651.418681,
     "geom:bbox":"-55.718222,-25.113142,-55.304041,-24.829474",
     "geom:latitude":-24.974212,
     "geom:longitude":-55.49037,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CG.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325756,
-    "wof:geomhash":"708808f9838995bd2d8589761eacae44",
+    "wof:geomhash":"35de9a7fe804e744b5a9ff2f38fba6cc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692835,
-    "wof:lastmodified":1627522522,
+    "wof:lastmodified":1695886169,
     "wof:name":"Nueva Toledo",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/110/869/283/9/1108692839.geojson
+++ b/data/110/869/283/9/1108692839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075813,
-    "geom:area_square_m":841284888.249493,
+    "geom:area_square_m":841285131.547498,
     "geom:bbox":"-56.410984,-26.406709,-56.104643,-25.976187",
     "geom:latitude":-26.178807,
     "geom:longitude":-56.288311,
@@ -157,9 +157,10 @@
         "hasc:id":"PY.CZ.CA",
         "wd:id":"Q135939"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325757,
-    "wof:geomhash":"a61a982099d36a072eba12d7566f8f06",
+    "wof:geomhash":"5f9e008a8888b3d697bd5538c2c54ef9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":1108692839,
-    "wof:lastmodified":1690857006,
+    "wof:lastmodified":1695886829,
     "wof:name":"Caazapa",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/284/1/1108692841.geojson
+++ b/data/110/869/284/1/1108692841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175946,
-    "geom:area_square_m":1957364081.884916,
+    "geom:area_square_m":1957364081.885348,
     "geom:bbox":"-56.0271601332,-26.1813341112,-55.399155771,-25.5235662678",
     "geom:latitude":-25.882618,
     "geom:longitude":-55.708855,
@@ -106,9 +106,10 @@
         "hasc:id":"PY.CZ.AB",
         "wd:id":"Q1318585"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325759,
-    "wof:geomhash":"4c8800716d0e580a7a322543c0ef6c19",
+    "wof:geomhash":"2afb1eeab4e4e97522e91fae6aee2421",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108692841,
-    "wof:lastmodified":1566609459,
+    "wof:lastmodified":1695886827,
     "wof:name":"Abai",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/284/3/1108692843.geojson
+++ b/data/110/869/284/3/1108692843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012181,
-    "geom:area_square_m":135125058.181949,
+    "geom:area_square_m":135124995.145658,
     "geom:bbox":"-56.152064,-26.292257,-56.015073,-26.155752",
     "geom:latitude":-26.220982,
     "geom:longitude":-56.082786,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.CZ.BV",
         "wd:id":"Q2475384"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325760,
-    "wof:geomhash":"ca12dc74120aa14fd08e44260ade6a3d",
+    "wof:geomhash":"12c8ff74fe2cef0591336197c71fd214",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692843,
-    "wof:lastmodified":1690857004,
+    "wof:lastmodified":1695886828,
     "wof:name":"Buena Vista",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/284/5/1108692845.geojson
+++ b/data/110/869/284/5/1108692845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062975,
-    "geom:area_square_m":697592728.611205,
+    "geom:area_square_m":697592728.611171,
     "geom:bbox":"-56.8050345701,-26.4927342249,-56.3756785617,-26.2642164528",
     "geom:latitude":-26.381816,
     "geom:longitude":-56.594576,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.CZ.DB",
         "wd:id":"Q582045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325761,
-    "wof:geomhash":"f2ff4c8daf386bb177ea36bd3ecbfd8a",
+    "wof:geomhash":"1926f896a98004fd8f9b382cfdc6b457",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692845,
-    "wof:lastmodified":1566609462,
+    "wof:lastmodified":1695886828,
     "wof:name":"Moises Bertoni",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/284/7/1108692847.geojson
+++ b/data/110/869/284/7/1108692847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027847,
-    "geom:area_square_m":309378531.061745,
+    "geom:area_square_m":309378531.061799,
     "geom:bbox":"-56.2274863455,-26.1557474074,-55.9817694476,-25.8908599433",
     "geom:latitude":-26.040841,
     "geom:longitude":-56.082351,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.CZ.GM",
         "wd:id":"Q1983611"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325762,
-    "wof:geomhash":"3a803da3135424a0a2112c6790446ec2",
+    "wof:geomhash":"ae05fbd4ff58ad8cf461a794a575d216",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692847,
-    "wof:lastmodified":1566609459,
+    "wof:lastmodified":1695886827,
     "wof:name":"General Higinio Morinigo",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/284/9/1108692849.geojson
+++ b/data/110/869/284/9/1108692849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037977,
-    "geom:area_square_m":421272535.788502,
+    "geom:area_square_m":421272535.78846,
     "geom:bbox":"-56.6996200361,-26.3195466283,-56.3677543817,-26.1165939463",
     "geom:latitude":-26.220557,
     "geom:longitude":-56.513324,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CZ.MA",
         "wd:id":"Q1748956"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325764,
-    "wof:geomhash":"7abd528c1c9e80373cbb6f502e9479a0",
+    "wof:geomhash":"f45da14f7c04f5407fe5dd78ffc91aef",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692849,
-    "wof:lastmodified":1566609458,
+    "wof:lastmodified":1695886826,
     "wof:name":"Maciel",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/285/1/1108692851.geojson
+++ b/data/110/869/285/1/1108692851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089872,
-    "geom:area_square_m":996841109.845073,
+    "geom:area_square_m":996841067.880598,
     "geom:bbox":"-56.113968,-26.448425,-55.697986,-26.07054",
     "geom:latitude":-26.231455,
     "geom:longitude":-55.900663,
@@ -94,9 +94,10 @@
         "hasc:id":"PY.CZ.SN",
         "wd:id":"Q2439360"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325765,
-    "wof:geomhash":"4e2ee7b00467550b62445c0eae5be18a",
+    "wof:geomhash":"f6fd747882eac305017f79c7eaf02318",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108692851,
-    "wof:lastmodified":1690857013,
+    "wof:lastmodified":1695886834,
     "wof:name":"San Juan Nepomuceno",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/285/3/1108692853.geojson
+++ b/data/110/869/285/3/1108692853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127048,
-    "geom:area_square_m":1409713924.417328,
+    "geom:area_square_m":1409713924.417241,
     "geom:bbox":"-55.8065558457,-26.4173905481,-55.2481921781,-25.9853999673",
     "geom:latitude":-26.188236,
     "geom:longitude":-55.529953,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.CZ.TA",
         "wd:id":"Q2475410"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325766,
-    "wof:geomhash":"76da48e818fc1d3ea101b148d36def72",
+    "wof:geomhash":"a80b6d8d8630108ad9f27375096140f2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692853,
-    "wof:lastmodified":1566609493,
+    "wof:lastmodified":1695886835,
     "wof:name":"Tavai",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/285/7/1108692857.geojson
+++ b/data/110/869/285/7/1108692857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085331,
-    "geom:area_square_m":943936116.381658,
+    "geom:area_square_m":943936116.381649,
     "geom:bbox":"-56.8491135732,-26.6815930863,-56.3251248443,-26.3652109777",
     "geom:latitude":-26.542052,
     "geom:longitude":-56.562008,
@@ -91,9 +91,10 @@
         "hasc:id":"PY.CZ.FY",
         "wd:id":"Q1983624"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325768,
-    "wof:geomhash":"f782a7c23a6f7303a50e433b854d6e5b",
+    "wof:geomhash":"8e1f87f9a8c406427a8881cd4dfcafff",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108692857,
-    "wof:lastmodified":1566609492,
+    "wof:lastmodified":1695886834,
     "wof:name":"Fulgencio Yegros",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/285/9/1108692859.geojson
+++ b/data/110/869/285/9/1108692859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065702,
-    "geom:area_square_m":727662162.290582,
+    "geom:area_square_m":727662257.850403,
     "geom:bbox":"-56.276113,-26.550933,-55.849491,-26.242633",
     "geom:latitude":-26.405487,
     "geom:longitude":-56.067656,
@@ -51,9 +51,10 @@
     "wof:concordances":{
         "hasc:id":"PY.CZ.YU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325770,
-    "wof:geomhash":"6104107846ffda6cdda79e0289969476",
+    "wof:geomhash":"733e8dc36ad35fed7c25be26d0720a82",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1108692859,
-    "wof:lastmodified":1627522520,
+    "wof:lastmodified":1695886165,
     "wof:name":"3 De Mayo",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/110/869/286/1/1108692861.geojson
+++ b/data/110/869/286/1/1108692861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027727,
-    "geom:area_square_m":304768578.860486,
+    "geom:area_square_m":304768390.961325,
     "geom:bbox":"-56.020418,-27.426313,-55.789282,-27.134262",
     "geom:latitude":-27.262248,
     "geom:longitude":-55.895232,
@@ -250,9 +250,10 @@
         "hasc:id":"PY.IT.EN",
         "wd:id":"Q47138"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325771,
-    "wof:geomhash":"b63a0075662110726e411c1d89803878",
+    "wof:geomhash":"a1f6c4c9a69b6680fbb206922942ba6a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -262,7 +263,7 @@
         }
     ],
     "wof:id":1108692861,
-    "wof:lastmodified":1690856989,
+    "wof:lastmodified":1695886816,
     "wof:name":"Encarnacion",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/286/3/1108692863.geojson
+++ b/data/110/869/286/3/1108692863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027266,
-    "geom:area_square_m":300420430.161556,
+    "geom:area_square_m":300420423.082154,
     "geom:bbox":"-55.761764,-27.109847,-55.41205,-26.766954",
     "geom:latitude":-26.99528,
     "geom:longitude":-55.545126,
@@ -139,9 +139,10 @@
         "hasc:id":"PY.IT.BV",
         "wd:id":"Q1986203"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325772,
-    "wof:geomhash":"544a0edaf6a4a9b7d4efc71c2b052d5e",
+    "wof:geomhash":"baac74acec15f62c619236a2489946b4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1108692863,
-    "wof:lastmodified":1642551741,
+    "wof:lastmodified":1695886504,
     "wof:name":"Bella Vista",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/286/5/1108692865.geojson
+++ b/data/110/869/286/5/1108692865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018719,
-    "geom:area_square_m":205572969.088391,
+    "geom:area_square_m":205572927.417527,
     "geom:bbox":"-55.854545,-27.44468,-55.662177,-27.2487",
     "geom:latitude":-27.356426,
     "geom:longitude":-55.763491,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.CA",
         "wd:id":"Q3651213"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325773,
-    "wof:geomhash":"aea164e717b959aca0803bed62e4610b",
+    "wof:geomhash":"5e6666df548820e584e224073a33e29c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692865,
-    "wof:lastmodified":1690856989,
+    "wof:lastmodified":1695886816,
     "wof:name":"Cambyreta",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/286/7/1108692867.geojson
+++ b/data/110/869/286/7/1108692867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042165,
-    "geom:area_square_m":465260880.607859,
+    "geom:area_square_m":465260880.607885,
     "geom:bbox":"-55.4807561212,-26.9692152518,-55.1308778731,-26.6701547395",
     "geom:latitude":-26.828817,
     "geom:longitude":-55.290862,
@@ -88,9 +88,10 @@
         "hasc:id":"PY.IT.CZ",
         "wd:id":"Q656452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325775,
-    "wof:geomhash":"4a07632be21ded8735da72d8eb07b69a",
+    "wof:geomhash":"8feb7f6f03c532dff02ee58e8b595947",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108692867,
-    "wof:lastmodified":1566609408,
+    "wof:lastmodified":1695886815,
     "wof:name":"Capitan Meza",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/110/869/286/9/1108692869.geojson
+++ b/data/110/869/286/9/1108692869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001977,
-    "geom:area_square_m":22076856.402826,
+    "geom:area_square_m":22076772.003965,
     "geom:bbox":"-57.597797,-25.455512,-57.534474,-25.384675",
     "geom:latitude":-25.418338,
     "geom:longitude":-57.561953,
@@ -205,9 +205,10 @@
         "hasc:id":"PY.CE.SA",
         "wd:id":"Q1093479"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325776,
-    "wof:geomhash":"81f577c18a9480c7cf091d4aee579c28",
+    "wof:geomhash":"665891f659d80f2ebe66edbd9989428a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -217,7 +218,7 @@
         }
     ],
     "wof:id":1108692869,
-    "wof:lastmodified":1690856988,
+    "wof:lastmodified":1695886504,
     "wof:name":"San Antonio",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/110/869/287/1/1108692871.geojson
+++ b/data/110/869/287/1/1108692871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0769,
-    "geom:area_square_m":844811888.20941,
+    "geom:area_square_m":844811888.209478,
     "geom:bbox":"-57.8752515945,-27.4441725127,-57.2497062927,-27.2036115655",
     "geom:latitude":-27.321283,
     "geom:longitude":-57.541161,
@@ -97,9 +97,10 @@
         "hasc:id":"PY.NE.CE",
         "wd:id":"Q2723843"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325777,
-    "wof:geomhash":"46adc68d42d2d3d2817da67abee2b6cb",
+    "wof:geomhash":"9b1d8143b3c0c3c33c9120ae2e88c88c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108692871,
-    "wof:lastmodified":1566609398,
+    "wof:lastmodified":1695886814,
     "wof:name":"Cerrito",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/287/5/1108692875.geojson
+++ b/data/110/869/287/5/1108692875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076283,
-    "geom:area_square_m":839119908.146032,
+    "geom:area_square_m":839119294.228492,
     "geom:bbox":"-58.018471,-27.281365,-57.218765,-27.018094",
     "geom:latitude":-27.176357,
     "geom:longitude":-57.582989,
@@ -85,9 +85,10 @@
         "hasc:id":"PY.NE.LA",
         "wd:id":"Q12012219"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325779,
-    "wof:geomhash":"11bf2ddeeffa4f1821acf8e724815f1d",
+    "wof:geomhash":"0eaef90d7b4ae93f05e564813599229a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108692875,
-    "wof:lastmodified":1690856985,
+    "wof:lastmodified":1695886814,
     "wof:name":"Los Laureles",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/287/7/1108692877.geojson
+++ b/data/110/869/287/7/1108692877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037002,
-    "geom:area_square_m":407016567.639573,
+    "geom:area_square_m":407016709.581334,
     "geom:bbox":"-58.017551,-27.298794,-57.781868,-27.054641",
     "geom:latitude":-27.178591,
     "geom:longitude":-57.915109,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"PY.NE.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325780,
-    "wof:geomhash":"efbc6ac64eb9275d34c5481332f85adb",
+    "wof:geomhash":"59794020aa6ef6dad390352004512cfd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108692877,
-    "wof:lastmodified":1627522524,
+    "wof:lastmodified":1695886173,
     "wof:name":"Villalbin",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/110/869/287/9/1108692879.geojson
+++ b/data/110/869/287/9/1108692879.geojson
@@ -202,6 +202,7 @@
         "hasc:id":"PY.BQ.GG",
         "wd:id":"Q733744"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325781,
     "wof:geomhash":"b68dd55fe15493803fc5506a290c081e",
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":1108692879,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886093,
     "wof:name":"Filadelfia",
     "wof:parent_id":85676659,
     "wof:placetype":"county",

--- a/data/110/869/288/1/1108692881.geojson
+++ b/data/110/869/288/1/1108692881.geojson
@@ -166,6 +166,7 @@
         "hasc:id":"PY.BQ.ME",
         "wd:id":"Q1704617"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1474325782,
     "wof:geomhash":"05c755becfda2cc2a0d92afdbdc36cd6",
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108692881,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886815,
     "wof:name":"Loma Plata",
     "wof:parent_id":85676659,
     "wof:placetype":"county",

--- a/data/421/166/713/421166713.geojson
+++ b/data/421/166/713/421166713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011511,
-    "geom:area_square_m":128689553.438333,
+    "geom:area_square_m":128689553.438066,
     "geom:bbox":"-57.673858,-25.380387,-57.52724,-25.223937",
     "geom:latitude":-25.291214,
     "geom:longitude":-57.604942,
@@ -87,6 +87,7 @@
         "hasc:id":"PY.AS.AS",
         "qs_pg:id":1264310
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         1125905513,
         85676651
@@ -96,7 +97,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d25ad31332d7287aee54c72a2c0303f9",
+    "wof:geomhash":"1395a7ef89e8ff61efce826c022b7e3e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421166713,
-    "wof:lastmodified":1627522520,
+    "wof:lastmodified":1695886164,
     "wof:name":"Asuncion",
     "wof:parent_id":85676651,
     "wof:placetype":"county",

--- a/data/421/166/801/421166801.geojson
+++ b/data/421/166/801/421166801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017484,
-    "geom:area_square_m":198371506.686621,
+    "geom:area_square_m":198371560.864739,
     "geom:bbox":"-57.340557,-23.499154,-57.131419,-23.370248",
     "geom:latitude":-23.427805,
     "geom:longitude":-57.231688,
@@ -146,12 +146,13 @@
         "qs_pg:id":1264281,
         "wd:id":"Q1990186"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008703,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc18a680941a35d424a369bdcc71a5ed",
+    "wof:geomhash":"932abe3a3c2c2a325569d9aeb9bb5d6f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421166801,
-    "wof:lastmodified":1642551764,
+    "wof:lastmodified":1695886513,
     "wof:name":"Belen",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/421/169/437/421169437.geojson
+++ b/data/421/169/437/421169437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013073,
-    "geom:area_square_m":145901811.3904,
+    "geom:area_square_m":145901762.082507,
     "geom:bbox":"-54.740117,-25.600135,-54.59361,-25.386655",
     "geom:latitude":-25.497955,
     "geom:longitude":-54.679745,
@@ -301,12 +301,13 @@
         "qs_pg:id":1264254,
         "wd:id":"Q192235"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008810,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6dd85be5913170c8ec16402e2ded6a50",
+    "wof:geomhash":"44bea4b1adef7ad793259c246093c418",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -316,7 +317,7 @@
         }
     ],
     "wof:id":421169437,
-    "wof:lastmodified":1690857032,
+    "wof:lastmodified":1695886009,
     "wof:name":"Ciudad Del Este",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/170/007/421170007.geojson
+++ b/data/421/170/007/421170007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024196,
-    "geom:area_square_m":266809587.494448,
+    "geom:area_square_m":266809682.809523,
     "geom:bbox":"-58.385315,-27.035814,-58.007267,-26.791086",
     "geom:latitude":-26.903144,
     "geom:longitude":-58.216801,
@@ -163,12 +163,13 @@
         "hasc:id":"PY.NE.PI",
         "qs_pg:id":772888
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008833,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"345f3cc913c313005dcebe1dd175c9f2",
+    "wof:geomhash":"827ee8266c7632f3e353accc8988bd92",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421170007,
-    "wof:lastmodified":1636503113,
+    "wof:lastmodified":1695886103,
     "wof:name":"Pilar",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/421/170/009/421170009.geojson
+++ b/data/421/170/009/421170009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008536,
-    "geom:area_square_m":95351399.225919,
+    "geom:area_square_m":95351399.225924,
     "geom:bbox":"-57.3313913749,-25.4513631878,-57.193009423,-25.3384258924",
     "geom:latitude":-25.393311,
     "geom:longitude":-57.26419,
@@ -200,12 +200,13 @@
         "qs_pg:id":772910,
         "wd:id":"Q643576"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008833,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"913beff254d54e873195f99ed9beb6fd",
+    "wof:geomhash":"a47b33610e3984a86b3daf220be8d7e1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":421170009,
-    "wof:lastmodified":1582360309,
+    "wof:lastmodified":1695886019,
     "wof:name":"Ypacarai",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/170/011/421170011.geojson
+++ b/data/421/170/011/421170011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02195,
-    "geom:area_square_m":241346724.98123,
+    "geom:area_square_m":241346724.981238,
     "geom:bbox":"-58.645827153,-27.3062192819,-58.4136981901,-27.1562372426",
     "geom:latitude":-27.227342,
     "geom:longitude":-58.514536,
@@ -110,12 +110,13 @@
         "qs_pg:id":772921,
         "wd:id":"Q1293157"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008833,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f23c697b9115e98e274b1feb583034b5",
+    "wof:geomhash":"3be9b63d05b91f51556f45e223d41fcd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421170011,
-    "wof:lastmodified":1582360309,
+    "wof:lastmodified":1695886020,
     "wof:name":"Paso De Patria",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/421/170/013/421170013.geojson
+++ b/data/421/170/013/421170013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009827,
-    "geom:area_square_m":109981262.546513,
+    "geom:area_square_m":109981206.075962,
     "geom:bbox":"-57.54323,-25.220958,-57.396415,-25.096463",
     "geom:latitude":-25.157466,
     "geom:longitude":-57.475046,
@@ -236,12 +236,13 @@
         "qs_pg:id":772935,
         "wd:id":"Q47058"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008833,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a755b54515edbde9fa0bab380823a9ff",
+    "wof:geomhash":"8edebad8aaa8fa1a7eff8ca60a9b17ff",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -251,7 +252,7 @@
         }
     ],
     "wof:id":421170013,
-    "wof:lastmodified":1690857054,
+    "wof:lastmodified":1695886018,
     "wof:name":"Limpio",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/170/015/421170015.geojson
+++ b/data/421/170/015/421170015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041653,
-    "geom:area_square_m":463861547.929224,
+    "geom:area_square_m":463861547.929661,
     "geom:bbox":"-57.4682092862,-25.8799443207,-57.1370830284,-25.6280469689",
     "geom:latitude":-25.759075,
     "geom:longitude":-57.328851,
@@ -122,12 +122,13 @@
         "qs_pg:id":772941,
         "wd:id":"Q1035409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008833,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea0c8f2c5c6d3fea62b8a0860476f112",
+    "wof:geomhash":"7f5409535a6896a899b5ad8cadbe321a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421170015,
-    "wof:lastmodified":1582360308,
+    "wof:lastmodified":1695886019,
     "wof:name":"Carapegua",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/421/170/017/421170017.geojson
+++ b/data/421/170/017/421170017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13882,
-    "geom:area_square_m":1529999000.530851,
+    "geom:area_square_m":1529999501.56165,
     "geom:bbox":"-57.430828,-27.174262,-56.907285,-26.710043",
     "geom:latitude":-26.9589,
     "geom:longitude":-57.145571,
@@ -140,12 +140,13 @@
         "qs_pg:id":772946,
         "wd:id":"Q2571376"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008833,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38f5b262bec2e48fa4dc2a6ef74577de",
+    "wof:geomhash":"425b47f2e44ad940727b4c6dab8b4186",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421170017,
-    "wof:lastmodified":1690857055,
+    "wof:lastmodified":1695886104,
     "wof:name":"San Ignacio",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/170/055/421170055.geojson
+++ b/data/421/170/055/421170055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00934,
-    "geom:area_square_m":104417110.39296,
+    "geom:area_square_m":104417291.90954,
     "geom:bbox":"-57.447979,-25.358877,-57.327387,-25.227507",
     "geom:latitude":-25.293912,
     "geom:longitude":-57.386338,
@@ -236,12 +236,13 @@
         "qs_pg:id":1264256,
         "wd:id":"Q135975"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008835,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63afb2bf3b438d98c2c8f3a00e179a18",
+    "wof:geomhash":"fe88438a5df8c2913e70894b1b3b6f51",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -251,7 +252,7 @@
         }
     ],
     "wof:id":421170055,
-    "wof:lastmodified":1690857055,
+    "wof:lastmodified":1695886020,
     "wof:name":"Aregua",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/170/059/421170059.geojson
+++ b/data/421/170/059/421170059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.41537,
-    "geom:area_square_m":4735003323.902467,
+    "geom:area_square_m":4735002643.81648,
     "geom:bbox":"-56.31487,-23.34686,-55.655794,-22.270394",
     "geom:latitude":-22.79291,
     "geom:longitude":-55.983437,
@@ -266,12 +266,13 @@
         "qs_pg:id":1264257,
         "wd:id":"Q849292"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008835,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ade577587401a6d555e5ceaec4cb1d1b",
+    "wof:geomhash":"3dc9a5c5c6028d61308628483848cbf8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -281,7 +282,7 @@
         }
     ],
     "wof:id":421170059,
-    "wof:lastmodified":1690857056,
+    "wof:lastmodified":1695886105,
     "wof:name":"Pedro Juan Caballero",
     "wof:parent_id":85676701,
     "wof:placetype":"county",

--- a/data/421/171/367/421171367.geojson
+++ b/data/421/171/367/421171367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.568623,
-    "geom:area_square_m":17748909109.793743,
+    "geom:area_square_m":17748906549.603512,
     "geom:bbox":"-59.417212,-25.354271,-57.149308,-23.062425",
     "geom:latitude":-23.780753,
     "geom:longitude":-58.047353,
@@ -233,12 +233,13 @@
         "qs_pg:id":1264308,
         "wd:id":"Q135953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8f3c0dd4f1363f3f1f0940b0e60e6771",
+    "wof:geomhash":"1fa68cb93c890ca3b9fd90689cc717dc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -248,7 +249,7 @@
         }
     ],
     "wof:id":421171367,
-    "wof:lastmodified":1690857065,
+    "wof:lastmodified":1695886107,
     "wof:name":"Villa Hayes",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/421/171/369/421171369.geojson
+++ b/data/421/171/369/421171369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016334,
-    "geom:area_square_m":179741655.562905,
+    "geom:area_square_m":179741549.48392,
     "geom:bbox":"-55.840658,-27.219925,-55.620825,-27.070011",
     "geom:latitude":-27.134346,
     "geom:longitude":-55.730891,
@@ -140,12 +140,13 @@
         "qs_pg:id":1264309,
         "wd:id":"Q1779583"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008891,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cb56c3b48ebbfe50c7600bb230626b8",
+    "wof:geomhash":"058abd5cdea4561b5d6198fb4e61e6d9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421171369,
-    "wof:lastmodified":1690857064,
+    "wof:lastmodified":1695886106,
     "wof:name":"Trinidad",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/171/423/421171423.geojson
+++ b/data/421/171/423/421171423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144166,
-    "geom:area_square_m":1583297481.963804,
+    "geom:area_square_m":1583297481.96392,
     "geom:bbox":"-56.8848368486,-27.5918335646,-56.2663839622,-27.1456534203",
     "geom:latitude":-27.354937,
     "geom:longitude":-56.504194,
@@ -113,12 +113,13 @@
         "qs_pg:id":1264294,
         "wd:id":"Q1476962"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008893,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97c06517a05e0da8e5889f7851a1931a",
+    "wof:geomhash":"64e9a4e3c70c57ddba5f7ff78fb80eae",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421171423,
-    "wof:lastmodified":1582360312,
+    "wof:lastmodified":1695886021,
     "wof:name":"San Cosme Y Damian",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/171/521/421171521.geojson
+++ b/data/421/171/521/421171521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000421,
-    "geom:area_square_m":4709342.336221,
+    "geom:area_square_m":4709313.769506,
     "geom:bbox":"-57.723389,-25.296843,-57.679804,-25.266663",
     "geom:latitude":-25.282829,
     "geom:longitude":-57.700578,
@@ -199,12 +199,13 @@
         "qs_pg:id":1264295,
         "wd:id":"Q541522"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008896,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f46df572688edd693b42ff74382eec4",
+    "wof:geomhash":"057ea782cccf36901630a0ca1cda443d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -220,7 +221,7 @@
         }
     ],
     "wof:id":421171521,
-    "wof:lastmodified":1690857062,
+    "wof:lastmodified":1695886022,
     "wof:name":"Nanawa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/171/537/421171537.geojson
+++ b/data/421/171/537/421171537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011272,
-    "geom:area_square_m":125701001.778659,
+    "geom:area_square_m":125701008.923654,
     "geom:bbox":"-54.71189,-25.668866,-54.581112,-25.537928",
     "geom:latitude":-25.596662,
     "geom:longitude":-54.641504,
@@ -146,12 +146,13 @@
         "qs_pg:id":1264296,
         "wd:id":"Q2201876"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008897,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a46d18be9a68a15140134375dd26ae5c",
+    "wof:geomhash":"bfb4ab8cc1dd32ef12af5613b8180145",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421171537,
-    "wof:lastmodified":1690857064,
+    "wof:lastmodified":1695886024,
     "wof:name":"Presidente Franco",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/171/777/421171777.geojson
+++ b/data/421/171/777/421171777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.314507,
-    "geom:area_square_m":72403941771.289062,
+    "geom:area_square_m":72403941539.128357,
     "geom:bbox":"-62.644617,-23.885785,-59.86904,-20.0892",
     "geom:latitude":-21.96421,
     "geom:longitude":-61.286816,
@@ -215,12 +215,13 @@
         "qs_pg:id":1264258,
         "wd:id":"Q1093167"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008906,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b77739a4cf836a5196bbd2b07cb99e6",
+    "wof:geomhash":"67f12443fcb6b7923a3df17f55c11bee",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":421171777,
-    "wof:lastmodified":1690857063,
+    "wof:lastmodified":1695886107,
     "wof:name":"Mariscal Estigarribia",
     "wof:parent_id":85676659,
     "wof:placetype":"county",

--- a/data/421/171/779/421171779.geojson
+++ b/data/421/171/779/421171779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.978678,
-    "geom:area_square_m":11020816757.980011,
+    "geom:area_square_m":11020819054.616014,
     "geom:bbox":"-58.717981,-25.102492,-57.416807,-23.802017",
     "geom:latitude":-24.396162,
     "geom:longitude":-58.045254,
@@ -203,12 +203,13 @@
         "qs_pg:id":1264279,
         "wd:id":"Q2475363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008906,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b3ae17e9321ac894eff291e08f22a258",
+    "wof:geomhash":"b21dbaee01a20bf66e20da094009555b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":421171779,
-    "wof:lastmodified":1690857063,
+    "wof:lastmodified":1695886022,
     "wof:name":"Benjamin Aceval",
     "wof:parent_id":85676671,
     "wof:placetype":"county",

--- a/data/421/171/781/421171781.geojson
+++ b/data/421/171/781/421171781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024198,
-    "geom:area_square_m":267853408.015144,
+    "geom:area_square_m":267853666.70141,
     "geom:bbox":"-57.25438,-26.571872,-56.995075,-26.376147",
     "geom:latitude":-26.466893,
     "geom:longitude":-57.122912,
@@ -124,12 +124,13 @@
         "qs_pg:id":1264282,
         "wd:id":"Q615791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008906,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dc9bd7492cbcbdcd07ca824bbf53f5ca",
+    "wof:geomhash":"c48b954d3fcb44cf8ba05b705dc123fc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421171781,
-    "wof:lastmodified":1690857066,
+    "wof:lastmodified":1695886024,
     "wof:name":"Villa Florida",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/171/783/421171783.geojson
+++ b/data/421/171/783/421171783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013114,
-    "geom:area_square_m":146647733.687984,
+    "geom:area_square_m":146647733.687955,
     "geom:bbox":"-57.2252655207,-25.3606686375,-57.0977417961,-25.1295892043",
     "geom:latitude":-25.259931,
     "geom:longitude":-57.15459,
@@ -116,12 +116,13 @@
         "qs_pg:id":1264283,
         "wd:id":"Q2410308"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008907,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"568750fd044f10a47c19e44f5187f631",
+    "wof:geomhash":"47c451c0884a878fdf35d96d038edfa2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421171783,
-    "wof:lastmodified":1582360313,
+    "wof:lastmodified":1695886024,
     "wof:name":"Atyra",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/172/673/421172673.geojson
+++ b/data/421/172/673/421172673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012435,
-    "geom:area_square_m":138922636.00046,
+    "geom:area_square_m":138922656.072002,
     "geom:bbox":"-57.200046,-25.456243,-57.0593,-25.302924",
     "geom:latitude":-25.38041,
     "geom:longitude":-57.126728,
@@ -191,12 +191,13 @@
         "qs_pg:id":1316118,
         "wd:id":"Q135959"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008950,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ba49fbaf1d8ab43c47de13afd633fdbb",
+    "wof:geomhash":"d1847f629dbaa32540da6e5e5078ed0f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":421172673,
-    "wof:lastmodified":1690857043,
+    "wof:lastmodified":1695886013,
     "wof:name":"Caacupe",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/172/933/421172933.geojson
+++ b/data/421/172/933/421172933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025108,
-    "geom:area_square_m":279181050.122414,
+    "geom:area_square_m":279181050.122446,
     "geom:bbox":"-56.2812456248,-26.0634123814,-56.1119214832,-25.8358284895",
     "geom:latitude":-25.941562,
     "geom:longitude":-56.197596,
@@ -125,12 +125,13 @@
         "qs_pg:id":485412,
         "wd:id":"Q2409529"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008959,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"449898bbaa4b154c22bad31c6c0172ec",
+    "wof:geomhash":"fd4ff5904277fd8e6aed823c2f553525",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421172933,
-    "wof:lastmodified":1582360304,
+    "wof:lastmodified":1695886015,
     "wof:name":"General Eugenio A. Garay",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/421/173/299/421173299.geojson
+++ b/data/421/173/299/421173299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025647,
-    "geom:area_square_m":286907917.845194,
+    "geom:area_square_m":286908112.912289,
     "geom:bbox":"-57.131705,-25.333961,-56.942515,-25.097273",
     "geom:latitude":-25.21599,
     "geom:longitude":-57.046555,
@@ -128,12 +128,13 @@
         "qs_pg:id":286282,
         "wd:id":"Q1092820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008977,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"780ffb416a89651990df3de70db5f008",
+    "wof:geomhash":"559cdd548b138d0457766c50ea73fdd4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421173299,
-    "wof:lastmodified":1690857041,
+    "wof:lastmodified":1695886011,
     "wof:name":"Tobati",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/173/301/421173301.geojson
+++ b/data/421/173/301/421173301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029281,
-    "geom:area_square_m":325889869.960576,
+    "geom:area_square_m":325889751.967058,
     "geom:bbox":"-56.536812,-25.919204,-56.275094,-25.722013",
     "geom:latitude":-25.830981,
     "geom:longitude":-56.408368,
@@ -256,12 +256,13 @@
         "qs_pg:id":286283,
         "wd:id":"Q288685"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459008977,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce4990584d039f3fcc554cb27e286102",
+    "wof:geomhash":"4e5fdd099cdb401db89ddde8b4f51206",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -271,7 +272,7 @@
         }
     ],
     "wof:id":421173301,
-    "wof:lastmodified":1690857040,
+    "wof:lastmodified":1695886514,
     "wof:name":"Villarrica",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/421/173/745/421173745.geojson
+++ b/data/421/173/745/421173745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035709,
-    "geom:area_square_m":397934590.392225,
+    "geom:area_square_m":397934523.383527,
     "geom:bbox":"-57.270393,-25.81888,-57.01619,-25.524966",
     "geom:latitude":-25.679938,
     "geom:longitude":-57.1421,
@@ -227,12 +227,13 @@
         "qs_pg:id":467350,
         "wd:id":"Q917103"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009004,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"00b000c4b5d71f5dd206e92dcda6f6f6",
+    "wof:geomhash":"f595fc580f44a8b5555885b15cfe067b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -242,7 +243,7 @@
         }
     ],
     "wof:id":421173745,
-    "wof:lastmodified":1690857042,
+    "wof:lastmodified":1695886012,
     "wof:name":"Paraguari",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/421/175/585/421175585.geojson
+++ b/data/421/175/585/421175585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011681,
-    "geom:area_square_m":130645353.872861,
+    "geom:area_square_m":130645353.872812,
     "geom:bbox":"-57.2999781409,-25.3296379993,-57.1510710797,-25.1296241099",
     "geom:latitude":-25.245935,
     "geom:longitude":-57.221646,
@@ -131,12 +131,13 @@
         "qs_pg:id":1002652,
         "wd:id":"Q2388597"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009072,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f5f2392989aa664b18efc7356579080f",
+    "wof:geomhash":"d7771ed91fa26b51c70ff81cca359e93",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":421175585,
-    "wof:lastmodified":1582360304,
+    "wof:lastmodified":1695886015,
     "wof:name":"Altos",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/180/053/421180053.geojson
+++ b/data/421/180/053/421180053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020148,
-    "geom:area_square_m":221606604.464852,
+    "geom:area_square_m":221606660.099061,
     "geom:bbox":"-55.927495,-27.319519,-55.68832,-27.075518",
     "geom:latitude":-27.189661,
     "geom:longitude":-55.811685,
@@ -119,12 +119,13 @@
         "qs_pg:id":286280,
         "wd:id":"Q1984703"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009243,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c06cecfb9419d90111a448c0e7095be",
+    "wof:geomhash":"1f1bf02a2cc321d955d40f01a9af9954",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421180053,
-    "wof:lastmodified":1690857038,
+    "wof:lastmodified":1695886011,
     "wof:name":"Capitan Miranda",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/180/931/421180931.geojson
+++ b/data/421/180/931/421180931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195705,
-    "geom:area_square_m":2161652121.766526,
+    "geom:area_square_m":2161651199.695698,
     "geom:bbox":"-57.743139,-27.057374,-57.00103,-26.388213",
     "geom:latitude":-26.712204,
     "geom:longitude":-57.405886,
@@ -215,12 +215,13 @@
         "qs_pg:id":467349,
         "wd:id":"Q530895"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009276,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"819ee6d85970c527f20650e1a7fa5e21",
+    "wof:geomhash":"bfc71c62b94ec2ff93d0953b82f80f31",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":421180931,
-    "wof:lastmodified":1690857037,
+    "wof:lastmodified":1695886100,
     "wof:name":"San Juan Bautista",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/421/182/833/421182833.geojson
+++ b/data/421/182/833/421182833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03625,
-    "geom:area_square_m":403947923.45541,
+    "geom:area_square_m":403947923.455624,
     "geom:bbox":"-54.8660840605,-25.7901376032,-54.6250820438,-25.5741921836",
     "geom:latitude":-25.686016,
     "geom:longitude":-54.751324,
@@ -112,12 +112,13 @@
         "qs_pg:id":772926,
         "wd:id":"Q2445810"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009348,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90b32a34fe134c458f374d31612e6c88",
+    "wof:geomhash":"8dbef3fd0743c1f1eec5d6a8b1040caf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421182833,
-    "wof:lastmodified":1582360312,
+    "wof:lastmodified":1695886022,
     "wof:name":"Los Cedrales",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/183/417/421183417.geojson
+++ b/data/421/183/417/421183417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083378,
-    "geom:area_square_m":931172488.275866,
+    "geom:area_square_m":931172312.165338,
     "geom:bbox":"-56.292372,-25.607682,-55.827904,-25.188015",
     "geom:latitude":-25.419216,
     "geom:longitude":-56.051728,
@@ -230,12 +230,13 @@
         "qs_pg:id":975245,
         "wd:id":"Q858120"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009368,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e537318ec2e8793a9d8205a4042c8abe",
+    "wof:geomhash":"367912922deb72c901e6c075991d30ad",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":421183417,
-    "wof:lastmodified":1690857057,
+    "wof:lastmodified":1695886020,
     "wof:name":"Caaguazu",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/421/184/207/421184207.geojson
+++ b/data/421/184/207/421184207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078892,
-    "geom:area_square_m":880584699.4993,
+    "geom:area_square_m":880584553.518239,
     "geom:bbox":"-56.677524,-25.708386,-56.148319,-25.230817",
     "geom:latitude":-25.486581,
     "geom:longitude":-56.421111,
@@ -250,12 +250,13 @@
         "qs_pg:id":990189,
         "wd:id":"Q935504"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009403,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de502f9c42473b876b2e63b97166bb66",
+    "wof:geomhash":"a61d8dd31d6c718c3ea958ecaef8f066",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -265,7 +266,7 @@
         }
     ],
     "wof:id":421184207,
-    "wof:lastmodified":1690857052,
+    "wof:lastmodified":1695886101,
     "wof:name":"Coronel Oviedo",
     "wof:parent_id":85676709,
     "wof:placetype":"county",

--- a/data/421/184/635/421184635.geojson
+++ b/data/421/184/635/421184635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080295,
-    "geom:area_square_m":887866605.247973,
+    "geom:area_square_m":887866605.248104,
     "geom:bbox":"-55.8865786371,-26.8229826618,-55.5884680558,-26.3581345049",
     "geom:latitude":-26.588302,
     "geom:longitude":-55.742062,
@@ -119,12 +119,13 @@
         "qs_pg:id":1002650,
         "wd:id":"Q1987240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009417,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40587ce59111cbe7e21648780f8b7784",
+    "wof:geomhash":"83530f764705ba2fe1c206f03062bf24",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421184635,
-    "wof:lastmodified":1582360305,
+    "wof:lastmodified":1695886017,
     "wof:name":"Alto Vera",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/184/639/421184639.geojson
+++ b/data/421/184/639/421184639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.693203,
-    "geom:area_square_m":19584749131.132858,
+    "geom:area_square_m":19584747325.203102,
     "geom:bbox":"-59.887103,-21.299326,-57.817327,-20.130321",
     "geom:latitude":-20.702051,
     "geom:longitude":-58.962122,
@@ -233,12 +233,13 @@
         "qs_pg:id":1002651,
         "wd:id":"Q136498"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009417,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9c97a4f7efcdde9d589363bf328e9cb",
+    "wof:geomhash":"08be15fcd02111e7efe0bdfb2b288084",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -248,7 +249,7 @@
         }
     ],
     "wof:id":421184639,
-    "wof:lastmodified":1690857053,
+    "wof:lastmodified":1695886102,
     "wof:name":"Fuerte Olimpo",
     "wof:parent_id":85676655,
     "wof:placetype":"county",

--- a/data/421/184/641/421184641.geojson
+++ b/data/421/184/641/421184641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026178,
-    "geom:area_square_m":292168180.327786,
+    "geom:area_square_m":292167982.63457,
     "geom:bbox":"-57.141261,-25.59176,-56.925668,-25.376095",
     "geom:latitude":-25.49637,
     "geom:longitude":-57.042193,
@@ -140,12 +140,13 @@
         "qs_pg:id":1002653,
         "wd:id":"Q1093471"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009417,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"66b485d627264d2c7efb9dbf39208479",
+    "wof:geomhash":"e9de1cb591e1a2eeabe38505fe4d5ef3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421184641,
-    "wof:lastmodified":1690857052,
+    "wof:lastmodified":1695886018,
     "wof:name":"Piribebuy",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/184/917/421184917.geojson
+++ b/data/421/184/917/421184917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018266,
-    "geom:area_square_m":203508525.267994,
+    "geom:area_square_m":203508525.268005,
     "geom:bbox":"-56.4566666509,-25.796979688,-56.28045736,-25.6220102044",
     "geom:latitude":-25.707726,
     "geom:longitude":-56.365788,
@@ -112,12 +112,13 @@
         "qs_pg:id":1014809,
         "wd:id":"Q1006425"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009426,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"795e37d4adc4e452b000a829620046eb",
+    "wof:geomhash":"a851e71b024f7851839bc8fdca836bb6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421184917,
-    "wof:lastmodified":1582360308,
+    "wof:lastmodified":1695886019,
     "wof:name":"Mbocayaty",
     "wof:parent_id":85676685,
     "wof:placetype":"county",

--- a/data/421/189/017/421189017.geojson
+++ b/data/421/189/017/421189017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031023,
-    "geom:area_square_m":341280983.581233,
+    "geom:area_square_m":341280983.581082,
     "geom:bbox":"-58.4313683393,-27.2902139003,-58.2556562546,-27.0259892081",
     "geom:latitude":-27.167899,
     "geom:longitude":-58.343994,
@@ -122,12 +122,13 @@
         "qs_pg:id":1109547,
         "wd:id":"Q2778877"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009602,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2bc915ccedd712f3a522b2c9aaa9892",
+    "wof:geomhash":"20e7e50b7548220c5ab854beb1c22a2c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421189017,
-    "wof:lastmodified":1582360303,
+    "wof:lastmodified":1695886013,
     "wof:name":"General Diaz",
     "wof:parent_id":85676691,
     "wof:placetype":"county",

--- a/data/421/189/267/421189267.geojson
+++ b/data/421/189/267/421189267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013677,
-    "geom:area_square_m":152963616.925878,
+    "geom:area_square_m":152963468.664348,
     "geom:bbox":"-57.542767,-25.324787,-57.349721,-25.179998",
     "geom:latitude":-25.250526,
     "geom:longitude":-57.457085,
@@ -269,12 +269,13 @@
         "qs_pg:id":1110373,
         "wd:id":"Q946497"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009615,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c7cf194734a14baa46d30865d30cf87a",
+    "wof:geomhash":"892d50b70e23e17eb142930d0298d96c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -284,7 +285,7 @@
         }
     ],
     "wof:id":421189267,
-    "wof:lastmodified":1690857042,
+    "wof:lastmodified":1695886012,
     "wof:name":"Luque",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/189/517/421189517.geojson
+++ b/data/421/189/517/421189517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106042,
-    "geom:area_square_m":1191781545.621789,
+    "geom:area_square_m":1191781545.622097,
     "geom:bbox":"-56.7162631518,-24.8943052674,-56.1024265003,-24.3447883808",
     "geom:latitude":-24.645818,
     "geom:longitude":-56.392447,
@@ -134,12 +134,13 @@
         "qs_pg:id":1113885,
         "wd:id":"Q1093463"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009627,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a73e64fb108cc83408698022ef743a6f",
+    "wof:geomhash":"2f92a04dfe4e7be2b13ef492f8d76374",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421189517,
-    "wof:lastmodified":1582360303,
+    "wof:lastmodified":1695886013,
     "wof:name":"San Estanislao",
     "wof:parent_id":85676675,
     "wof:placetype":"county",

--- a/data/421/189/519/421189519.geojson
+++ b/data/421/189/519/421189519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02756,
-    "geom:area_square_m":303072305.521981,
+    "geom:area_square_m":303072596.967914,
     "geom:bbox":"-56.194844,-27.308322,-55.993186,-27.069365",
     "geom:latitude":-27.208451,
     "geom:longitude":-56.098259,
@@ -119,12 +119,13 @@
         "qs_pg:id":1113886,
         "wd:id":"Q1043738"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009627,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"efe8e3865fd5b1a8c825fa269cad7068",
+    "wof:geomhash":"0338647ca590c19ef64231607f6be6f4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421189519,
-    "wof:lastmodified":1690857043,
+    "wof:lastmodified":1695886015,
     "wof:name":"Carmen Del Parana",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/191/491/421191491.geojson
+++ b/data/421/191/491/421191491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002401,
-    "geom:area_square_m":26825122.429433,
+    "geom:area_square_m":26825181.926732,
     "geom:bbox":"-57.64208,-25.389412,-57.586135,-25.312522",
     "geom:latitude":-25.353615,
     "geom:longitude":-57.61576,
@@ -245,12 +245,13 @@
         "qs_pg:id":1137367,
         "wd:id":"Q47052"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009694,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3f795428532135a3b876fb51670d167c",
+    "wof:geomhash":"05e2ede0703b3faf317e83ee850352db",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -260,7 +261,7 @@
         }
     ],
     "wof:id":421191491,
-    "wof:lastmodified":1690857048,
+    "wof:lastmodified":1695886016,
     "wof:name":"Lambare",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/191/497/421191497.geojson
+++ b/data/421/191/497/421191497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018232,
-    "geom:area_square_m":203109329.151527,
+    "geom:area_square_m":203109207.579056,
     "geom:bbox":"-57.076929,-25.85241,-56.89134,-25.572428",
     "geom:latitude":-25.715259,
     "geom:longitude":-56.973658,
@@ -128,12 +128,13 @@
         "qs_pg:id":1137370,
         "wd:id":"Q785504"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009694,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"75cd36d24486abda02bb2286241ed0ef",
+    "wof:geomhash":"0903f8ec6c6dfa4795a04d79fb63ac3b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421191497,
-    "wof:lastmodified":1690857047,
+    "wof:lastmodified":1695886016,
     "wof:name":"Sapucai",
     "wof:parent_id":85676699,
     "wof:placetype":"county",

--- a/data/421/191/499/421191499.geojson
+++ b/data/421/191/499/421191499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071325,
-    "geom:area_square_m":796571048.087439,
+    "geom:area_square_m":796571048.087757,
     "geom:bbox":"-55.3284595323,-25.5927341305,-54.8920439016,-25.2492280747",
     "geom:latitude":-25.417794,
     "geom:longitude":-55.100238,
@@ -199,12 +199,13 @@
         "qs_pg:id":1137372,
         "wd:id":"Q2639179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009694,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cfe0b6b90e49366bd1139f0c961bc3d8",
+    "wof:geomhash":"a11fc47bf116fedb0ac17b1e1385da8c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -214,7 +215,7 @@
         }
     ],
     "wof:id":421191499,
-    "wof:lastmodified":1582360304,
+    "wof:lastmodified":1695886016,
     "wof:name":"Yguazu",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/193/197/421193197.geojson
+++ b/data/421/193/197/421193197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010785,
-    "geom:area_square_m":120573464.373845,
+    "geom:area_square_m":120573360.780802,
     "geom:bbox":"-57.373973,-25.366863,-57.212262,-25.201009",
     "geom:latitude":-25.293135,
     "geom:longitude":-57.293282,
@@ -127,12 +127,13 @@
         "qs_pg:id":772957,
         "wd:id":"Q388644"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009763,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d09b4a7146490a2f01d872dffe092ca",
+    "wof:geomhash":"60a810f5616ec69eb10294e9db165b59",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421193197,
-    "wof:lastmodified":1690857029,
+    "wof:lastmodified":1695886010,
     "wof:name":"San Bernardino",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/193/629/421193629.geojson
+++ b/data/421/193/629/421193629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069603,
-    "geom:area_square_m":778004905.140927,
+    "geom:area_square_m":778004858.577766,
     "geom:bbox":"-55.028539,-25.504585,-54.531345,-25.13783",
     "geom:latitude":-25.315057,
     "geom:longitude":-54.777812,
@@ -218,12 +218,13 @@
         "qs_pg:id":15374,
         "wd:id":"Q2271787"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009777,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5c975cbdd259bfad5ad904149e291dcd",
+    "wof:geomhash":"976918555d48d4a88382b5bc97ad0fa1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -233,7 +234,7 @@
         }
     ],
     "wof:id":421193629,
-    "wof:lastmodified":1690857029,
+    "wof:lastmodified":1695886010,
     "wof:name":"Hernandarias",
     "wof:parent_id":85676705,
     "wof:placetype":"county",

--- a/data/421/194/567/421194567.geojson
+++ b/data/421/194/567/421194567.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007875,
-    "geom:area_square_m":87981103.076316,
+    "geom:area_square_m":87981100.973973,
     "geom:bbox":"-57.51672,-25.439108,-57.398345,-25.307826",
     "geom:latitude":-25.377225,
     "geom:longitude":-57.451897,
@@ -236,12 +236,13 @@
         "qs_pg:id":772930,
         "wd:id":"Q723811"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009812,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cec1c41e49954d76b28a6634145a227f",
+    "wof:geomhash":"56106151d22904f5224c20c7618699db",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -251,7 +252,7 @@
         }
     ],
     "wof:id":421194567,
-    "wof:lastmodified":1690857028,
+    "wof:lastmodified":1695886008,
     "wof:name":"Capiata",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/195/021/421195021.geojson
+++ b/data/421/195/021/421195021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078177,
-    "geom:area_square_m":870957642.397613,
+    "geom:area_square_m":870957704.126733,
     "geom:bbox":"-57.826763,-25.95255,-57.413046,-25.477461",
     "geom:latitude":-25.711554,
     "geom:longitude":-57.607137,
@@ -209,12 +209,13 @@
         "qs_pg:id":116276,
         "wd:id":"Q1093439"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"58dac1bda5615e855ee320f28328ac98",
+    "wof:geomhash":"0b4ae048f9845ab62277ba1a218154de",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -224,7 +225,7 @@
         }
     ],
     "wof:id":421195021,
-    "wof:lastmodified":1690857027,
+    "wof:lastmodified":1695886009,
     "wof:name":"Villeta",
     "wof:parent_id":85676681,
     "wof:placetype":"county",

--- a/data/421/195/025/421195025.geojson
+++ b/data/421/195/025/421195025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102029,
-    "geom:area_square_m":1128001397.210224,
+    "geom:area_square_m":1128001302.8688,
     "geom:bbox":"-56.662111,-26.794376,-56.094861,-26.372378",
     "geom:latitude":-26.607242,
     "geom:longitude":-56.335234,
@@ -122,12 +122,13 @@
         "qs_pg:id":116278,
         "wd:id":"Q2475423"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459009829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b43e7a167db22db110e1bd8e00d69cd3",
+    "wof:geomhash":"c977aa158d55dab6ab113ef6d6116d24",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421195025,
-    "wof:lastmodified":1690857026,
+    "wof:lastmodified":1695886007,
     "wof:name":"Yuty",
     "wof:parent_id":85676713,
     "wof:placetype":"county",

--- a/data/421/201/641/421201641.geojson
+++ b/data/421/201/641/421201641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.626594,
-    "geom:area_square_m":7138352786.622112,
+    "geom:area_square_m":7138351402.386449,
     "geom:bbox":"-57.940635,-23.509491,-56.649068,-22.364207",
     "geom:latitude":-22.879311,
     "geom:longitude":-57.367775,
@@ -254,12 +254,13 @@
         "qs_pg:id":1264255,
         "wd:id":"Q840962"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459010079,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce26655461a167fce91ec6769d836d32",
+    "wof:geomhash":"e8ea87349f4a90bdc0386c847d4c4890",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -269,7 +270,7 @@
         }
     ],
     "wof:id":421201641,
-    "wof:lastmodified":1690857051,
+    "wof:lastmodified":1695886017,
     "wof:name":"Concepcion",
     "wof:parent_id":85676665,
     "wof:placetype":"county",

--- a/data/421/201/649/421201649.geojson
+++ b/data/421/201/649/421201649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019903,
-    "geom:area_square_m":221970387.203244,
+    "geom:area_square_m":221970273.898543,
     "geom:bbox":"-56.980261,-25.668976,-56.719684,-25.507642",
     "geom:latitude":-25.588521,
     "geom:longitude":-56.870654,
@@ -169,12 +169,13 @@
         "qs_pg:id":1264280,
         "wd:id":"Q1754826"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459010079,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02139a48cc6f6ad3c8e25360dd9ced0b",
+    "wof:geomhash":"fc552b8f9d2d2c0890a8c45651177e96",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":421201649,
-    "wof:lastmodified":1636503111,
+    "wof:lastmodified":1695886100,
     "wof:name":"Valenzuela",
     "wof:parent_id":85676667,
     "wof:placetype":"county",

--- a/data/421/204/307/421204307.geojson
+++ b/data/421/204/307/421204307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012701,
-    "geom:area_square_m":139868912.365705,
+    "geom:area_square_m":139868966.288012,
     "geom:bbox":"-55.87917,-27.113781,-55.665728,-26.992066",
     "geom:latitude":-27.053637,
     "geom:longitude":-55.774181,
@@ -112,12 +112,13 @@
         "qs_pg:id":239113,
         "wd:id":"Q1688403"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459010180,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"579679df8f44b5e33a43c85532794ee1",
+    "wof:geomhash":"892ff4109795620b728b691402bfb742",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421204307,
-    "wof:lastmodified":1690857033,
+    "wof:lastmodified":1695886010,
     "wof:name":"Jesus",
     "wof:parent_id":85676723,
     "wof:placetype":"county",

--- a/data/421/204/309/421204309.geojson
+++ b/data/421/204/309/421204309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077749,
-    "geom:area_square_m":853762343.296291,
+    "geom:area_square_m":853762256.206692,
     "geom:bbox":"-57.341979,-27.486148,-56.664877,-27.267269",
     "geom:latitude":-27.370135,
     "geom:longitude":-56.974898,
@@ -140,12 +140,13 @@
         "qs_pg:id":239114,
         "wd:id":"Q793189"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PY",
     "wof:created":1459010180,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d08444481c102e25f2ddb5c6dd5803e",
+    "wof:geomhash":"4842c6c1f9b50c9251a2725a4ca416a7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421204309,
-    "wof:lastmodified":1690857033,
+    "wof:lastmodified":1695886011,
     "wof:name":"Ayolas",
     "wof:parent_id":85676689,
     "wof:placetype":"county",

--- a/data/856/323/55/85632355.geojson
+++ b/data/856/323/55/85632355.geojson
@@ -1178,6 +1178,7 @@
         "hasc:id":"PY",
         "icao:code":"ZP",
         "ioc:id":"PAR",
+        "iso:code":"PY",
         "itu:id":"PRG",
         "m49:code":"600",
         "marc:id":"py",
@@ -1191,6 +1192,7 @@
         "wk:page":"Paraguay",
         "wmo:id":"PY"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:country_alpha3":"PRY",
     "wof:geom_alt":[
@@ -1214,7 +1216,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1694639559,
+    "wof:lastmodified":1695881217,
     "wof:name":"Paraguay",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/766/51/85676651.geojson
+++ b/data/856/766/51/85676651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011511,
-    "geom:area_square_m":128689553.438333,
+    "geom:area_square_m":128689553.438066,
     "geom:bbox":"-57.673858,-25.380387,-57.52724,-25.223937",
     "geom:latitude":-25.291214,
     "geom:longitude":-57.604942,
@@ -614,11 +614,13 @@
         "gn:id":3474570,
         "gp:id":20070148,
         "hasc:id":"PY.AS",
+        "iso:code":"PY-ASU",
         "iso:id":"PY-ASU",
         "qs_pg:id":219910,
         "unlc:id":"PY-ASU",
         "wd:id":"Q2933"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421166713,
         1125905513
@@ -627,7 +629,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d25ad31332d7287aee54c72a2c0303f9",
+    "wof:geomhash":"1395a7ef89e8ff61efce826c022b7e3e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -644,7 +646,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856976,
+    "wof:lastmodified":1695884655,
     "wof:name":"Asunci\u00f3n",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/55/85676655.geojson
+++ b/data/856/766/55/85676655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.806045,
-    "geom:area_square_m":78767137469.687286,
+    "geom:area_square_m":78767133792.559067,
     "geom:bbox":"-61.9224,-22.399223,-57.817149,-19.2896",
     "geom:latitude":-20.604826,
     "geom:longitude":-59.384297,
@@ -318,16 +318,18 @@
         "gn:id":3439441,
         "gp:id":2346463,
         "hasc:id":"PY.AG",
+        "iso:code":"PY-16",
         "iso:id":"PY-16",
         "qs_pg:id":894954,
         "wd:id":"Q682642",
         "wk:page":"Alto Paraguay Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2a8cdfdecbd4112172d72977fd96a716",
+    "wof:geomhash":"65b0ce898d262ed7ef5c7ad5dff5242c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -344,7 +346,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856980,
+    "wof:lastmodified":1695885134,
     "wof:name":"Alto Paraguay",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/59/85676659.geojson
+++ b/data/856/766/59/85676659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.716395,
-    "geom:area_square_m":88527758487.836914,
+    "geom:area_square_m":88527760169.562439,
     "geom:bbox":"-62.644617,-23.885785,-59.336595,-20.0892",
     "geom:latitude":-21.886237,
     "geom:longitude":-61.075515,
@@ -320,17 +320,19 @@
         "gn:id":3867442,
         "gp:id":2346450,
         "hasc:id":"PY.BQ",
+        "iso:code":"PY-19",
         "iso:id":"PY-19",
         "qs_pg:id":894943,
         "unlc:id":"PY-19",
         "wd:id":"Q741017",
         "wk:page":"Boquer\u00f3n department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"560f75b5ebd0276a227db66c8c6ce736",
+    "wof:geomhash":"3fa01ad95df207bfda462c5a772c1111",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -347,7 +349,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856975,
+    "wof:lastmodified":1695884372,
     "wof:name":"Boquer\u00f3n",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/65/85676665.geojson
+++ b/data/856/766/65/85676665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.631337,
-    "geom:area_square_m":18589779981.537918,
+    "geom:area_square_m":18589779502.212677,
     "geom:bbox":"-57.993784,-23.509491,-56.125778,-22.079088",
     "geom:latitude":-22.84042,
     "geom:longitude":-57.10986,
@@ -264,6 +264,7 @@
         "gn:id":3438833,
         "gp:id":2346454,
         "hasc:id":"PY.CN",
+        "iso:code":"PY-1",
         "iso:id":"PY-1",
         "loc:id":"no2003101128",
         "qs_pg:id":1083856,
@@ -271,11 +272,12 @@
         "wd:id":"Q741009",
         "wk:page":"Concepci\u00f3n Department, Paraguay"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3dc4bf561d3ad4d092ff28b4d45757e",
+    "wof:geomhash":"749f492874e0a9b984297f23af4e2872",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -292,7 +294,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856979,
+    "wof:lastmodified":1695884372,
     "wof:name":"Concepci\u00f3n",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/67/85676667.geojson
+++ b/data/856/766/67/85676667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.429117,
-    "geom:area_square_m":4800644279.244635,
+    "geom:area_square_m":4800645289.556777,
     "geom:bbox":"-57.478317,-25.668976,-56.561362,-24.843279",
     "geom:latitude":-25.211164,
     "geom:longitude":-56.961853,
@@ -307,17 +307,19 @@
         "gn:id":3438827,
         "gp:id":2346455,
         "hasc:id":"PY.CR",
+        "iso:code":"PY-3",
         "iso:id":"PY-3",
         "qs_pg:id":222826,
         "unlc:id":"PY-3",
         "wd:id":"Q755121",
         "wk:page":"Cordillera Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4da1e6eae6051046df72bda395bcc770",
+    "wof:geomhash":"bf17ac3402b064595bc39b4588ea238d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -334,7 +336,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856976,
+    "wof:lastmodified":1695884948,
     "wof:name":"Cordillera",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/71/85676671.geojson
+++ b/data/856/766/71/85676671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.517372,
-    "geom:area_square_m":73831481730.673004,
+    "geom:area_square_m":73831481720.756088,
     "geom:bbox":"-60.785391,-25.354271,-57.149308,-22.076224",
     "geom:latitude":-23.619163,
     "geom:longitude":-58.682325,
@@ -316,17 +316,19 @@
         "gn:id":3437443,
         "gp:id":2346461,
         "hasc:id":"PY.PH",
+        "iso:code":"PY-15",
         "iso:id":"PY-15",
         "qs_pg:id":890096,
         "unlc:id":"PY-15",
         "wd:id":"Q750551",
         "wk:page":"Presidente Hayes Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d00a5d43c0841ba3da8fa7e615ffb3b3",
+    "wof:geomhash":"9150523f052c3b8c4f32c84e1f88c218",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -343,7 +345,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856981,
+    "wof:lastmodified":1695884950,
     "wof:name":"Presidente Hayes",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/75/85676675.geojson
+++ b/data/856/766/75/85676675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.852798,
-    "geom:area_square_m":20899992348.68058,
+    "geom:area_square_m":20899992813.740276,
     "geom:bbox":"-57.473517,-25.019252,-55.701991,-23.300696",
     "geom:latitude":-24.177005,
     "geom:longitude":-56.630933,
@@ -317,17 +317,19 @@
         "gn:id":3437027,
         "gp:id":2346462,
         "hasc:id":"PY.SP",
+        "iso:code":"PY-2",
         "iso:id":"PY-2",
         "qs_pg:id":894948,
         "unlc:id":"PY-2",
         "wd:id":"Q526176",
         "wk:page":"San Pedro Department, Paraguay"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a5709d556765ee492f827f31486ad256",
+    "wof:geomhash":"09c4aea8d07baca6020e9b8ec96e220e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -344,7 +346,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856977,
+    "wof:lastmodified":1695884949,
     "wof:name":"San Pedro",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/81/85676681.geojson
+++ b/data/856/766/81/85676681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.21676,
-    "geom:area_square_m":2418143171.993568,
+    "geom:area_square_m":2418143021.67934,
     "geom:bbox":"-57.826763,-26.025117,-57.193009,-25.096463",
     "geom:latitude":-25.550429,
     "geom:longitude":-57.501662,
@@ -323,17 +323,19 @@
         "gn:id":3439137,
         "gp:id":2346453,
         "hasc:id":"PY.CE",
+        "iso:code":"PY-11",
         "iso:id":"PY-11",
         "qs_pg:id":894947,
         "unlc:id":"PY-11",
         "wd:id":"Q372461",
         "wk:page":"Central Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c8faca17bb88508dbb8fa6ceff866996",
+    "wof:geomhash":"915f2492b2c644df97014b76ef05b656",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -350,7 +352,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856978,
+    "wof:lastmodified":1695884950,
     "wof:name":"Central",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/85/85676685.geojson
+++ b/data/856/766/85/85676685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.348432,
-    "geom:area_square_m":3877928018.578444,
+    "geom:area_square_m":3877928903.86185,
     "geom:bbox":"-56.747686,-26.197312,-55.633414,-25.564776",
     "geom:latitude":-25.831164,
     "geom:longitude":-56.300528,
@@ -317,17 +317,19 @@
         "gn:id":3438049,
         "gp:id":2346456,
         "hasc:id":"PY.GU",
+        "iso:code":"PY-4",
         "iso:id":"PY-4",
         "qs_pg:id":222827,
         "unlc:id":"PY-4",
         "wd:id":"Q755116",
         "wk:page":"Guair\u00e1 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48563c5b0e7f3c34007c604dd0faca0e",
+    "wof:geomhash":"306dfbe8741cb7699682985d190d321d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -344,7 +346,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856980,
+    "wof:lastmodified":1695884373,
     "wof:name":"Guair\u00e1",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/89/85676689.geojson
+++ b/data/856/766/89/85676689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.741457,
-    "geom:area_square_m":8174931257.203284,
+    "geom:area_square_m":8174929489.667304,
     "geom:bbox":"-57.743139,-27.486148,-56.625861,-26.376147",
     "geom:latitude":-26.916642,
     "geom:longitude":-57.094524,
@@ -310,17 +310,19 @@
         "gn:id":3437727,
         "gp:id":2346458,
         "hasc:id":"PY.MI",
+        "iso:code":"PY-8",
         "iso:id":"PY-8",
         "qs_pg:id":890095,
         "unlc:id":"PY-8",
         "wd:id":"Q591194",
         "wk:page":"Misiones Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6bd9945a8f329bfac3df63f64131a32d",
+    "wof:geomhash":"71e1d78e6cc149cf6eb0ed08beec3539",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -337,7 +339,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856977,
+    "wof:lastmodified":1695884949,
     "wof:name":"Misiones",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/91/85676691.geojson
+++ b/data/856/766/91/85676691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.059534,
-    "geom:area_square_m":11696509623.801065,
+    "geom:area_square_m":11696511408.936218,
     "geom:bbox":"-58.664912,-27.444173,-57.182094,-25.767176",
     "geom:latitude":-26.773408,
     "geom:longitude":-57.8975,
@@ -317,17 +317,19 @@
         "gn:id":3437677,
         "gp:id":2346459,
         "hasc:id":"PY.NE",
+        "iso:code":"PY-12",
         "iso:id":"PY-12",
         "qs_pg:id":1168709,
         "unlc:id":"PY-12",
         "wd:id":"Q755115",
         "wk:page":"\u00d1eembuc\u00fa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90a78d5a1b0d6a01d7a577d93c34d011",
+    "wof:geomhash":"54316ec74b9a627ccbe8f2b73f9469ed",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -344,7 +346,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856978,
+    "wof:lastmodified":1695884372,
     "wof:name":"\u00d1eembuc\u00fa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/766/99/85676699.geojson
+++ b/data/856/766/99/85676699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.775962,
-    "geom:area_square_m":8619504286.052525,
+    "geom:area_square_m":8619504493.165745,
     "geom:bbox":"-57.749377,-26.619597,-56.607556,-25.401783",
     "geom:latitude":-26.057883,
     "geom:longitude":-57.137185,
@@ -266,17 +266,19 @@
         "gn:id":3437599,
         "gp:id":2346460,
         "hasc:id":"PY.PG",
+        "iso:code":"PY-9",
         "iso:id":"PY-9",
         "qs_pg:id":1097047,
         "unlc:id":"PY-9",
         "wd:id":"Q240014",
         "wk:page":"Paraguar\u00ed Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68209bd5afda0f95efbeef6a0b96d5bd",
+    "wof:geomhash":"be4c14fc83983f20310edab220f26a70",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -293,7 +295,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856979,
+    "wof:lastmodified":1695884373,
     "wof:name":"Paraguar\u00ed",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/01/85676701.geojson
+++ b/data/856/767/01/85676701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.104926,
-    "geom:area_square_m":12587297849.938017,
+    "geom:area_square_m":12587297961.372078,
     "geom:bbox":"-56.826067,-23.830937,-55.504321,-22.074456",
     "geom:latitude":-22.880042,
     "geom:longitude":-56.060955,
@@ -313,17 +313,19 @@
         "gn:id":3439433,
         "gp:id":2346449,
         "hasc:id":"PY.AM",
+        "iso:code":"PY-13",
         "iso:id":"PY-13",
         "qs_pg:id":235621,
         "unlc:id":"PY-13",
         "wd:id":"Q686586",
         "wk:page":"Amambay Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d544e35b818af8474658d2f2b93b851",
+    "wof:geomhash":"b8ab26b8ae30791e3b542a1e9197ad7a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -340,7 +342,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856972,
+    "wof:lastmodified":1695884947,
     "wof:name":"Amambay",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/05/85676705.geojson
+++ b/data/856/767/05/85676705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.274689,
-    "geom:area_square_m":14238176318.837379,
+    "geom:area_square_m":14238176428.868757,
     "geom:bbox":"-55.55064,-26.257108,-54.345807,-24.476246",
     "geom:latitude":-25.395834,
     "geom:longitude":-54.952766,
@@ -326,17 +326,19 @@
         "gn:id":3439440,
         "gp:id":2346448,
         "hasc:id":"PY.AA",
+        "iso:code":"PY-10",
         "iso:id":"PY-10",
         "qs_pg:id":1047041,
         "unlc:id":"PY-10",
         "wd:id":"Q682654",
         "wk:page":"Alto Paran\u00e1 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3e6b131da66f3c085bf72a921435ad97",
+    "wof:geomhash":"6ffc03d3801a6cd3d78f3e7296a3c52e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -353,7 +355,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856969,
+    "wof:lastmodified":1695884367,
     "wof:name":"Alto Paran\u00e1",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/09/85676709.geojson
+++ b/data/856/767/09/85676709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.155827,
-    "geom:area_square_m":12931672336.750763,
+    "geom:area_square_m":12931670660.118847,
     "geom:bbox":"-56.856444,-25.708386,-54.923227,-24.465456",
     "geom:latitude":-25.200041,
     "geom:longitude":-55.886177,
@@ -320,17 +320,19 @@
         "gn:id":3439312,
         "gp:id":2346451,
         "hasc:id":"PY.CG",
+        "iso:code":"PY-5",
         "iso:id":"PY-5",
         "qs_pg:id":1097060,
         "unlc:id":"PY-5",
         "wd:id":"Q880399",
         "wk:page":"Caaguaz\u00fa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2dfbed3744ad491a1f704eb330c75409",
+    "wof:geomhash":"0a3bf7a1f64c8bb1d6469d2db9fc587c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -347,7 +349,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856971,
+    "wof:lastmodified":1695884368,
     "wof:name":"Caaguaz\u00fa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/13/85676713.geojson
+++ b/data/856/767/13/85676713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.862723,
-    "geom:area_square_m":9568172533.921345,
+    "geom:area_square_m":9568172103.24086,
     "geom:bbox":"-56.849114,-26.794376,-55.248192,-25.523566",
     "geom:latitude":-26.241934,
     "geom:longitude":-56.056601,
@@ -311,17 +311,19 @@
         "gn:id":3439296,
         "gp:id":2346452,
         "hasc:id":"PY.CZ",
+        "iso:code":"PY-6",
         "iso:id":"PY-6",
         "qs_pg:id":894953,
         "unlc:id":"PY-6",
         "wd:id":"Q881839",
         "wk:page":"Caazap\u00e1 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"495aa847e8517fe6b04cf3a1c2470c41",
+    "wof:geomhash":"3b37caf6a5e96d6fee20427bdfdaed8d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -338,7 +340,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856974,
+    "wof:lastmodified":1695884370,
     "wof:name":"Caazap\u00e1",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/19/85676719.geojson
+++ b/data/856/767/19/85676719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.338899,
-    "geom:area_square_m":15096818792.489574,
+    "geom:area_square_m":15096818581.55159,
     "geom:bbox":"-56.172538,-24.78397,-54.258924,-23.523292",
     "geom:latitude":-24.232715,
     "geom:longitude":-55.21934,
@@ -317,17 +317,19 @@
         "gn:id":3439216,
         "gp:id":2346464,
         "hasc:id":"PY.CY",
+        "iso:code":"PY-14",
         "iso:id":"PY-14",
         "qs_pg:id":1097059,
         "unlc:id":"PY-14",
         "wd:id":"Q279085",
         "wk:page":"Canindey\u00fa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9434969d5951ef475b06626feba68e1d",
+    "wof:geomhash":"1f00189bc5308961014a47ae382c0b75",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -344,7 +346,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856970,
+    "wof:lastmodified":1695884652,
     "wof:name":"Canindey\u00fa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",

--- a/data/856/767/23/85676723.geojson
+++ b/data/856/767/23/85676723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.440705,
-    "geom:area_square_m":15895067810.396797,
+    "geom:area_square_m":15895068706.934893,
     "geom:bbox":"-56.884837,-27.591834,-54.648161,-26.092162",
     "geom:latitude":-26.840824,
     "geom:longitude":-55.759976,
@@ -314,17 +314,19 @@
         "gn:id":3437923,
         "gp:id":2346457,
         "hasc:id":"PY.IT",
+        "iso:code":"PY-7",
         "iso:id":"PY-7",
         "qs_pg:id":453723,
         "unlc:id":"PY-7",
         "wd:id":"Q222564",
         "wk:page":"Itap\u00faa Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PY",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4920005b8fb91c1ea065a3c775c44b5c",
+    "wof:geomhash":"9e2cf0502c5c4d52cc32b18a873a0213",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -341,7 +343,7 @@
         "grn",
         "spa"
     ],
-    "wof:lastmodified":1690856973,
+    "wof:lastmodified":1695884369,
     "wof:name":"Itap\u00faa",
     "wof:parent_id":85632355,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.